### PR TITLE
Adding a "filename" to URLDownloader

### DIFF
--- a/SketchupMake/SketchUpMake.download.recipe
+++ b/SketchupMake/SketchUpMake.download.recipe
@@ -35,6 +35,11 @@
 			</dict>
 		</dict>
 		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>filename</key>
+				<string>SketchUpMake.dmg</string>
+			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>
 		</dict>


### PR DESCRIPTION
The text on the download webpage no longer has ".dmg" at the end of it.
It instead has "-dmg" (e.g. "sketchupmake-2017-3-116-90853-fr-dmg").
This causes recipes that act on the .dmg to fail. Giving URLDownloader
a file name allows the recipe to succeed.