### PR TITLE
Mattermost is no longer distributed as an archive.

### DIFF
--- a/Mattermost/Mattermost.munki.recipe
+++ b/Mattermost/Mattermost.munki.recipe
@@ -19,10 +19,6 @@
 	<string>com.github.peshay.download.Mattermost</string>
 	<key>Process</key>
 	<array>
-		<dict>
-			<key>Processor</key>
-			<string>Unarchiver</string>
-		</dict>
         <dict>
             <key>Arguments</key>
             <dict>


### PR DESCRIPTION
Mattermost is no longer distributed as an archive but as a dmg.