### PR TITLE
Mattermost is distributed as an dmg now.

### DIFF
--- a/Mattermost/Mattermost.munki.recipe
+++ b/Mattermost/Mattermost.munki.recipe
@@ -38,7 +38,7 @@
 	<string>com.github.peshay.download.Mattermost</string>
 	<key>Process</key>
 	<array>
-		<dict>
+	<dict>
             <key>Arguments</key>
             <dict>
                 <key>pkg_path</key>

--- a/Mattermost/Mattermost.munki.recipe
+++ b/Mattermost/Mattermost.munki.recipe
@@ -12,6 +12,25 @@
 		<string>Mattermost</string>
         <key>MUNKI_REPO_SUBDIR</key>
         <string>collab/%NAME%</string>
+		<key>pkginfo</key>
+        <dict>
+            <key>catalogs</key>
+            <array>
+                <string>testing</string>
+            </array>
+            <key>description</key>
+            <string>Mattermost: Open Source, Private Cloud Slack Alternative</string>
+            <key>display_name</key>
+            <string>Mattermost Private Cloud Messaging</string>
+            <key>name</key>
+            <string>%NAME%</string>
+            <key>unattended_install</key>
+            <true/>
+            <key>supported_architectures</key>
+            <array>
+                <string>x86_64</string>
+            </array>
+        </dict>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>
@@ -20,31 +39,16 @@
 	<key>Process</key>
 	<array>
 		<dict>
-			<key>Processor</key>
-			<string>Unarchiver</string>
-		</dict>
-        <dict>
             <key>Arguments</key>
             <dict>
-                <key>dmg_root</key>
-                <string>%RECIPE_CACHE_DIR%/%NAME%</string>
-                <key>dmg_path</key>
-                <string>%RECIPE_CACHE_DIR%/%NAME%.dmg</string>
+                <key>pkg_path</key>
+                <string>%pathname%</string>
+                <key>repo_subdirectory</key>
+                <string>%MUNKI_REPO_SUBDIR%</string>
             </dict>
             <key>Processor</key>
-            <string>DmgCreator</string>
+            <string>MunkiImporter</string>
         </dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>repo_subdirectory</key>
-				<string>%MUNKI_REPO_SUBDIR%</string>
-				<key>pkg_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%.dmg</string>
-			</dict>
-			<key>Processor</key>
-			<string>MunkiImporter</string>
-		</dict>
 	</array>
 </dict>
 </plist>


### PR DESCRIPTION
Because Mattermost is downloaded as dmg, we dont need DmgCreator anymore.