### PR TITLE
Remove NAME variable from app paths

### DIFF
--- a/CNIL/PIA.install.recipe
+++ b/CNIL/PIA.install.recipe
@@ -28,7 +28,7 @@
 						<key>destination_path</key>
 						<string>/Applications</string>
 						<key>source_item</key>
-						<string>%NAME%.app</string>
+						<string>PIA.app</string>
 					</dict>
 				</array>
 			</dict>

--- a/CNIL/PIA.pkg.recipe
+++ b/CNIL/PIA.pkg.recipe
@@ -37,9 +37,9 @@
 			<key>Arguments</key>
 			<dict>
 				<key>destination_path</key>
-				<string>%pkgroot%/Applications/%NAME%.app</string>
+				<string>%pkgroot%/Applications/PIA.app</string>
 				<key>source_path</key>
-				<string>%pathname%/%NAME%.app</string>
+				<string>%pathname%/PIA.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>Copier</string>

--- a/Elgato Systems GmbH/Elgato Video Capture.install.recipe
+++ b/Elgato Systems GmbH/Elgato Video Capture.install.recipe
@@ -30,7 +30,7 @@
 						<key>destination_path</key>
 						<string>/Applications</string>
 						<key>source_item</key>
-						<string>%NAME%.app</string>
+						<string>Elgato Video Capture.app</string>
 					</dict>
 				</array>
 			</dict>

--- a/Elgato Systems GmbH/Elgato Video Capture.pkg.recipe
+++ b/Elgato Systems GmbH/Elgato Video Capture.pkg.recipe
@@ -39,9 +39,9 @@
 			<key>Arguments</key>
 			<dict>
 				<key>destination_path</key>
-				<string>%pkgroot%/Applications/%NAME%.app</string>
+				<string>%pkgroot%/Applications/Elgato Video Capture.app</string>
 				<key>source_path</key>
-				<string>%pathname%/%NAME%.app</string>
+				<string>%pathname%/Elgato Video Capture.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>Copier</string>

--- a/Krystof Vasa/Downie.download.recipe
+++ b/Krystof Vasa/Downie.download.recipe
@@ -58,7 +58,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/Downie.app</string>
 				<key>requirement</key>
 				<string>anchor apple generic and identifier "com.charliemonroe.Downie.2.0" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = D43XN356JM)</string>
 			</dict>

--- a/Krystof Vasa/Downie.install.recipe
+++ b/Krystof Vasa/Downie.install.recipe
@@ -41,7 +41,7 @@
 						<key>destination_path</key>
 						<string>/Applications</string>
 						<key>source_item</key>
-						<string>%NAME%.app</string>
+						<string>Downie.app</string>
 					</dict>
 				</array>
 			</dict>

--- a/Techno-Grafik Christian Lackner eU/iTaskX3.download.recipe
+++ b/Techno-Grafik Christian Lackner eU/iTaskX3.download.recipe
@@ -58,7 +58,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/iTaskX3.app</string>
 				<key>requirement</key>
 				<string>anchor apple generic and identifier "at.techno-grafik.iTaskX3" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = N25S94343Z)</string>
 			</dict>

--- a/Techno-Grafik Christian Lackner eU/iTaskX3.install.recipe
+++ b/Techno-Grafik Christian Lackner eU/iTaskX3.install.recipe
@@ -41,7 +41,7 @@
 						<key>destination_path</key>
 						<string>/Applications</string>
 						<key>source_item</key>
-						<string>%NAME%.app</string>
+						<string>iTaskX3.app</string>
 					</dict>
 				</array>
 			</dict>

--- a/Texpad/Texpad.download.recipe
+++ b/Texpad/Texpad.download.recipe
@@ -45,7 +45,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%pathname%/%NAME%.app</string>
+				<string>%pathname%/Texpad.app</string>
 				<key>requirement</key>
 				<string>anchor apple generic and identifier "com.vallettaventures.Texpad" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "4R4V82SR58")</string>
 			</dict>

--- a/Texpad/Texpad.install.recipe
+++ b/Texpad/Texpad.install.recipe
@@ -30,7 +30,7 @@
 						<key>destination_path</key>
 						<string>/Applications</string>
 						<key>source_item</key>
-						<string>%NAME%.app</string>
+						<string>Texpad.app</string>
 					</dict>
 				</array>
 			</dict>

--- a/Texpad/Texpad.pkg.recipe
+++ b/Texpad/Texpad.pkg.recipe
@@ -39,9 +39,9 @@
 			<key>Arguments</key>
 			<dict>
 				<key>destination_path</key>
-				<string>%pkgroot%/Applications/%NAME%.app</string>
+				<string>%pkgroot%/Applications/Texpad.app</string>
 				<key>source_path</key>
-				<string>%pathname%/%NAME%.app</string>
+				<string>%pathname%/Texpad.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>Copier</string>

--- a/Texpad/TexpadBeta.download.recipe
+++ b/Texpad/TexpadBeta.download.recipe
@@ -45,7 +45,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%pathname%/%NAME%.app</string>
+				<string>%pathname%/Texpad Beta.app</string>
 				<key>requirement</key>
 				<string>anchor apple generic and identifier "com.vallettaventures.Texpad" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "4R4V82SR58")</string>
 			</dict>

--- a/Texpad/TexpadBeta.install.recipe
+++ b/Texpad/TexpadBeta.install.recipe
@@ -30,7 +30,7 @@
 						<key>destination_path</key>
 						<string>/Applications</string>
 						<key>source_item</key>
-						<string>%NAME%.app</string>
+						<string>Texpad Beta.app</string>
 					</dict>
 				</array>
 			</dict>

--- a/Texpad/TexpadBeta.pkg.recipe
+++ b/Texpad/TexpadBeta.pkg.recipe
@@ -39,9 +39,9 @@
 			<key>Arguments</key>
 			<dict>
 				<key>destination_path</key>
-				<string>%pkgroot%/Applications/%NAME%.app</string>
+				<string>%pkgroot%/Applications/Texpad Beta.app</string>
 				<key>source_path</key>
-				<string>%pathname%/%NAME%.app</string>
+				<string>%pathname%/Texpad Beta.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>Copier</string>


### PR DESCRIPTION
Because variables can be overridden, it's a good idea to make sure that the recipe will still work even if a non-default variables used. One issue that would prevent recipes from running is using a `NAME` variable in paths that should be hard-coded (e.g. `/Applications/Foo.app`).

This PR removes the `NAME` variable from all file paths and replaces it with the actual app name, which should make the recipe more resilient for overrides.