### PR TITLE
Basic python3 compatibility

### DIFF
--- a/Composer/PHPComposerURLProvider.py
+++ b/Composer/PHPComposerURLProvider.py
@@ -22,7 +22,7 @@ class ComposerURLFinder(HTMLParser):
                # If href is defined, print it.
                if name == "href":
                    self.urls.append(value)
-                   
+
 class PHPComposerURLProvider(Processor):
     """Provides a version and dmg download for Composer command line tool."""
     description = __doc__
@@ -86,20 +86,20 @@ class PHPComposerURLProvider(Processor):
                     has_changed = True
                     selected_version = a_version
         return selected_version
-        
+
     def main(self):
         '''Find the last version number and URL'''
-            
+
         if 'source_url' in self.env:
         	self.source_url = self.env['source_url']
-        	
+
         if 'url_pattern' in self.env:
         	self.url_pattern = self.env['url_pattern']
 
         try:
             all_downlaod_URLs_per_version = self.get_all_downlaod_URLs_per_version()
-        
-            last_version = self.get_highest_version(all_downlaod_URLs_per_version.keys())
+
+            last_version = self.get_highest_version(all_downlaod_URLs_per_version)
             last_version_url = all_downlaod_URLs_per_version[last_version]
         except Exception as e:
             raise ProcessorError("Could not get a download URL: %s" % e)

--- a/Composer/PHPComposerURLProvider.py
+++ b/Composer/PHPComposerURLProvider.py
@@ -1,12 +1,12 @@
 #!/usr/bin/python
 
 from __future__ import absolute_import
-from HTMLParser import HTMLParser
+
 import re
 import urllib2
 import urlparse
-
-from distutils.version import LooseVersion, StrictVersion
+from distutils.version import LooseVersion
+from HTMLParser import HTMLParser
 
 from autopkglib import Processor, ProcessorError
 

--- a/Composer/PHPComposerURLProvider.py
+++ b/Composer/PHPComposerURLProvider.py
@@ -105,7 +105,7 @@ class PHPComposerURLProvider(Processor):
 
             last_version = self.get_highest_version(all_download_URLs_per_version)
             last_version_url = all_download_URLs_per_version[last_version]
-        except Exception as e:
+        except BaseException as e:
             raise ProcessorError("Could not get a download URL: %s" % e)
 
         self.env["version"] = last_version

--- a/Composer/PHPComposerURLProvider.py
+++ b/Composer/PHPComposerURLProvider.py
@@ -1,5 +1,6 @@
 #!/usr/bin/python
 
+from __future__ import absolute_import
 from HTMLParser import HTMLParser
 import re
 import urllib2
@@ -70,7 +71,7 @@ class PHPComposerURLProvider(Processor):
                     version = m.group(1)
                     download_urls[version] = url
 
-        except urllib2.HTTPError, ValueError:
+        except urllib2.HTTPError as ValueError:
             raise ProcessorError("Could not parse downloads metadata.")
         return download_urls
 

--- a/Composer/PHPComposerURLProvider.py
+++ b/Composer/PHPComposerURLProvider.py
@@ -56,7 +56,7 @@ class PHPComposerURLProvider(Processor):
     }
 
 
-    def get_all_downlaod_URLs_per_version(self):
+    def get_all_download_URLs_per_version(self):
         '''Return a list of download URLs.'''
         try:
             html_content = urllib2.urlopen(self.source_url).read()
@@ -97,10 +97,10 @@ class PHPComposerURLProvider(Processor):
         	self.url_pattern = self.env['url_pattern']
 
         try:
-            all_downlaod_URLs_per_version = self.get_all_downlaod_URLs_per_version()
+            all_download_URLs_per_version = self.get_all_download_URLs_per_version()
 
-            last_version = self.get_highest_version(all_downlaod_URLs_per_version)
-            last_version_url = all_downlaod_URLs_per_version[last_version]
+            last_version = self.get_highest_version(all_download_URLs_per_version)
+            last_version_url = all_download_URLs_per_version[last_version]
         except Exception as e:
             raise ProcessorError("Could not get a download URL: %s" % e)
 

--- a/Composer/PHPComposerURLProvider.py
+++ b/Composer/PHPComposerURLProvider.py
@@ -3,12 +3,16 @@
 from __future__ import absolute_import
 
 import re
-import urllib2
 import urlparse
 from distutils.version import LooseVersion
 from HTMLParser import HTMLParser
 
 from autopkglib import Processor, ProcessorError
+
+try:
+    from urllib.parse import urlopen  # For Python 3
+except ImportError:
+    from urllib2 import urlopen  # For Python 2
 
 __all__ = ["PHPComposerURLProvider"]
 
@@ -59,7 +63,7 @@ class PHPComposerURLProvider(Processor):
     def get_all_download_URLs_per_version(self):
         '''Return a list of download URLs.'''
         try:
-            html_content = urllib2.urlopen(self.source_url).read()
+            html_content = urlopen(self.source_url).read()
             parser = ComposerURLFinder()
             parser.feed(html_content)
             url_pattern = re.compile(self.url_pattern )
@@ -71,7 +75,7 @@ class PHPComposerURLProvider(Processor):
                     version = m.group(1)
                     download_urls[version] = url
 
-        except urllib2.HTTPError as ValueError:
+        except:
             raise ProcessorError("Could not parse downloads metadata.")
         return download_urls
 

--- a/Composer/PHPComposerURLProvider.py
+++ b/Composer/PHPComposerURLProvider.py
@@ -105,7 +105,7 @@ class PHPComposerURLProvider(Processor):
 
             last_version = self.get_highest_version(all_download_URLs_per_version)
             last_version_url = all_download_URLs_per_version[last_version]
-        except BaseException as e:
+        except Exception as e:
             raise ProcessorError("Could not get a download URL: %s" % e)
 
         self.env["version"] = last_version

--- a/Composer/PHPComposerURLProvider.py
+++ b/Composer/PHPComposerURLProvider.py
@@ -18,10 +18,10 @@ class ComposerURLFinder(HTMLParser):
         # Only parse the 'anchor' tag.
         if tag == "a":
            # Check the list of defined attributes.
-           for name, value in attrs:
-               # If href is defined, print it.
-               if name == "href":
-                   self.urls.append(value)
+            for name, value in attrs:
+                # If href is defined, print it.
+                if name == "href":
+                    self.urls.append(value)
 
 class PHPComposerURLProvider(Processor):
     """Provides a version and dmg download for Composer command line tool."""
@@ -91,10 +91,10 @@ class PHPComposerURLProvider(Processor):
         '''Find the last version number and URL'''
 
         if 'source_url' in self.env:
-        	self.source_url = self.env['source_url']
+            self.source_url = self.env['source_url']
 
         if 'url_pattern' in self.env:
-        	self.url_pattern = self.env['url_pattern']
+            self.url_pattern = self.env['url_pattern']
 
         try:
             all_download_URLs_per_version = self.get_all_download_URLs_per_version()

--- a/GitCommitAndPush/GitCommitAndPush.py
+++ b/GitCommitAndPush/GitCommitAndPush.py
@@ -16,6 +16,8 @@
 
 """See docstring for GitCommitAndPush class"""
 
+from __future__ import absolute_import
+from __future__ import print_function
 from autopkglib import Processor
 from subprocess import call
 
@@ -23,7 +25,7 @@ from subprocess import call
 try:
     from Foundation import CFPreferencesCopyAppValue
 except:
-    print "WARNING: Failed 'from Foundation import CFPreferencesCopyAppValue' in " + __name__
+    print("WARNING: Failed 'from Foundation import CFPreferencesCopyAppValue' in " + __name__)
 #pylint: enable=no-name-in-module
 
 __all__ = ["GitCommitAndPush"]

--- a/GitCommitAndPush/GitCommitAndPush.py
+++ b/GitCommitAndPush/GitCommitAndPush.py
@@ -16,10 +16,11 @@
 
 """See docstring for GitCommitAndPush class"""
 
-from __future__ import absolute_import
-from __future__ import print_function
-from autopkglib import Processor
+from __future__ import absolute_import, print_function
+
 from subprocess import call
+
+from autopkglib import Processor
 
 #pylint: disable=no-name-in-module
 try:

--- a/GitFatCommitAndPush/GitFatCommitAndPush.py
+++ b/GitFatCommitAndPush/GitFatCommitAndPush.py
@@ -16,10 +16,11 @@
 
 """See docstring for GitFatCommitAndPush class"""
 
-from __future__ import absolute_import
-from __future__ import print_function
-from autopkglib import Processor
+from __future__ import absolute_import, print_function
+
 from subprocess import call
+
+from autopkglib import Processor
 
 #pylint: disable=no-name-in-module
 try:

--- a/GitFatCommitAndPush/GitFatCommitAndPush.py
+++ b/GitFatCommitAndPush/GitFatCommitAndPush.py
@@ -16,6 +16,8 @@
 
 """See docstring for GitFatCommitAndPush class"""
 
+from __future__ import absolute_import
+from __future__ import print_function
 from autopkglib import Processor
 from subprocess import call
 
@@ -23,7 +25,7 @@ from subprocess import call
 try:
     from Foundation import CFPreferencesCopyAppValue
 except:
-    print "WARNING: Failed 'from Foundation import CFPreferencesCopyAppValue' in " + __name__
+    print("WARNING: Failed 'from Foundation import CFPreferencesCopyAppValue' in " + __name__)
 #pylint: enable=no-name-in-module
 
 __all__ = ["GitFatCommitAndPush"]

--- a/MunkiNormalizePath/MunkiNormalizePath.py
+++ b/MunkiNormalizePath/MunkiNormalizePath.py
@@ -70,7 +70,7 @@ class MunkiNormalizePath(Processor):
         original_subdir = self.env["MUNKI_REPO_SUBDIR"] if "MUNKI_REPO_SUBDIR" in self.env else None
         original_subdir_munki = self.env["repo_subdirectory"] if "repo_subdirectory" in self.env else None
         if original_name:
-            self.env["NAME"] = re.sub('[^0-9a-zA-Z/]+', '_', original_name.lower())
+            self.env["NAME"] = re.sub(r'[^0-9a-zA-Z/]+', '_', original_name.lower())
             self.output("Updated NAME with %s" % self.env["NAME"])
             if original_displayname is None:
                 self.output("No original DISPLAYNAME, adding one")
@@ -81,10 +81,10 @@ class MunkiNormalizePath(Processor):
                     self.env["pkginfo"]["display_name"] = original_name
                     self.output("Updated display_name with %s" % original_name)
         if original_subdir:
-            self.env["MUNKI_REPO_SUBDIR"] = re.sub('[^0-9a-zA-Z/]+', '_', original_subdir.lower())
+            self.env["MUNKI_REPO_SUBDIR"] = re.sub(r'[^0-9a-zA-Z/]+', '_', original_subdir.lower())
             self.output("Updated MUNKI_REPO_SUBDIR with %s" % self.env["MUNKI_REPO_SUBDIR"])
         if original_subdir_munki:
-            self.env["repo_subdirectory"] = re.sub('[^0-9a-zA-Z/]+', '_', original_subdir_munki.lower())
+            self.env["repo_subdirectory"] = re.sub(r'[^0-9a-zA-Z/]+', '_', original_subdir_munki.lower())
             self.output("Updated repo_subdirectory with %s" % self.env["repo_subdirectory"])
 
 if __name__ == "__main__":

--- a/MunkiNormalizePath/MunkiNormalizePath.py
+++ b/MunkiNormalizePath/MunkiNormalizePath.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 """See docstring for MunkiNormalizePath class"""
 
+from __future__ import absolute_import
 from autopkglib import Processor
 import re 
 

--- a/MunkiNormalizePath/MunkiNormalizePath.py
+++ b/MunkiNormalizePath/MunkiNormalizePath.py
@@ -16,8 +16,10 @@
 """See docstring for MunkiNormalizePath class"""
 
 from __future__ import absolute_import
+
+import re
+
 from autopkglib import Processor
-import re 
 
 __all__ = ["MunkiNormalizePath"]
 

--- a/RunSyncCommand/RunSyncCommand.py
+++ b/RunSyncCommand/RunSyncCommand.py
@@ -17,8 +17,10 @@
 """See docstring for RunSyncCommand class"""
 
 from __future__ import absolute_import
-from autopkglib import Processor
+
 from subprocess import call
+
+from autopkglib import Processor
 
 __all__ = ["RunSyncCommand"]
 

--- a/RunSyncCommand/RunSyncCommand.py
+++ b/RunSyncCommand/RunSyncCommand.py
@@ -16,6 +16,7 @@
 
 """See docstring for RunSyncCommand class"""
 
+from __future__ import absolute_import
 from autopkglib import Processor
 from subprocess import call
 


### PR DESCRIPTION
In order to make your processors more compatible with AutoPkg running in Python 3, I've applied a few adjustments suggested by `python-modernize`, `pylint --py3k`, and `pylint` in general.

More adjustments may need to be made manually later (including `urlparse` and `HTMLParser` in PHPComposerURLProvider), but this should catch the low-hanging fruit right now.