### PR TITLE
Remove unused BUNDLE_ID input var

### DIFF
--- a/Postico/Postico.pkg.recipe
+++ b/Postico/Postico.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.ygini.pkg.Postico</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>at.eggerapps.Postico</string>
 		<key>NAME</key>
 		<string>Postico</string>
 	</dict>
@@ -24,10 +22,10 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>pkg_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%.dmg</string>
 				<key>app_path</key>
 				<string>%RECIPE_CACHE_DIR%/%NAME%/*.app</string>
+				<key>pkg_path</key>
+				<string>%RECIPE_CACHE_DIR%/%NAME%.dmg</string>
 			</dict>
 			<key>Processor</key>
 			<string>AppPkgCreator</string>


### PR DESCRIPTION
This pull request removes unused instances of `BUNDLE_ID` from recipe input variables, which will help reduce confusion by new AutoPkg users and simplify overrides created from this point on.

Making `BUNDLE_ID` available as an input variable is a common practice in AutoPkg recipes that use the [PkgCreator](https://github.com/autopkg/autopkg/wiki/Processor-PkgCreator) processor ([example](https://github.com/autopkg/homebysix-recipes/blob/4fec9244a3af0f9b7c8f61f35a5cd7f4622fb162/soma-zone/LaunchControl.pkg.recipe#L40-L41)). It's likely that these recipes transitioned from PkgCreator to the more streamlined [AppPkgCreator](https://github.com/autopkg/autopkg/wiki/Processor-AppPkgCreator) processor some time ago, but the now-unused input variable for `BUNDLE_ID` was never removed.

Because an automated script helped make this change, modified recipes have also been converted to align with the output of `plutil -convert xml` and Python's `plistlib`. This results in reordering of dictionary keys and reindentation using tabs, neither of which will affect the recipe's function.

Recipe run output is included below for all changed recipes (excluding jss and install recipe types). Any run failures are very likely to be unrelated to this change.

## ✅ Postico/Postico.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/ygini-recipes/Postico/Postico.pkg.recipe
Processing repos/ygini-recipes/Postico/Postico.pkg.recipe...
URLDownloader
{'Input': {'filename': 'Postico.zip',
           'url': 'https://eggerapps.at/postico/download/'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.ygini.pkg.Postico/downloads/Postico.zip
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.ygini.pkg.Postico/downloads/Postico.zip'}}
Unarchiver
{'Input': {}}
Unarchiver: Guessed archive format 'zip' from filename Postico.zip
Unarchiver: Unarchived ~/Library/AutoPkg/Cache/com.github.ygini.pkg.Postico/downloads/Postico.zip to ~/Library/AutoPkg/Cache/com.github.ygini.pkg.Postico/Postico
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.ygini.pkg.Postico/Postico/Postico.app',
           'requirement': 'anchor apple generic and identifier '
                          '"at.eggerapps.Postico" and (certificate '
                          'leaf[field.1.2.840.113635.100.6.1.9] /* exists */ '
                          'or certificate 1[field.1.2.840.113635.100.6.2.6] /* '
                          'exists */ and certificate '
                          'leaf[field.1.2.840.113635.100.6.1.13] /* exists */ '
                          'and certificate leaf[subject.OU] = ZF84SJ5A3G)'}}
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.ygini.pkg.Postico/Postico/Postico.app: valid on disk
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.ygini.pkg.Postico/Postico/Postico.app: satisfies its Designated Requirement
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.ygini.pkg.Postico/Postico/Postico.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
AppPkgCreator
{'Input': {'app_path': '~/Library/AutoPkg/Cache/com.github.ygini.pkg.Postico/Postico/*.app',
           'pkg_path': '~/Library/AutoPkg/Cache/com.github.ygini.pkg.Postico/Postico.dmg'}}
AppPkgCreator: Using path '~/Library/AutoPkg/Cache/com.github.ygini.pkg.Postico/Postico/Postico.app' matched from globbed '~/Library/AutoPkg/Cache/com.github.ygini.pkg.Postico/Postico/*.app'.
AppPkgCreator: Version: 1.5.17
AppPkgCreator: BundleID: at.eggerapps.Postico
AppPkgCreator: Copied ~/Library/AutoPkg/Cache/com.github.ygini.pkg.Postico/Postico/Postico.app to ~/Library/AutoPkg/Cache/com.github.ygini.pkg.Postico/payload/Applications/Postico.app
AppPkgCreator: Connecting
AppPkgCreator: Sending packaging request
AppPkgCreator: Disconnecting
AppPkgCreator: Failed to close socket: [Errno 9] Bad file descriptor
{'Output': {'app_pkg_creator_summary_result': {'data': {'identifier': 'at.eggerapps.Postico',
                                                        'pkg_path': '~/Library/AutoPkg/Cache/com.github.ygini.pkg.Postico/Postico.pkg',
                                                        'version': '1.5.17'},
                                               'report_fields': ['identifier',
                                                                 'version',
                                                                 'pkg_path'],
                                               'summary_text': 'The following '
                                                               'packages were '
                                                               'built:'},
            'new_package_request': True,
            'version': '1.5.17'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.ygini.pkg.Postico/receipts/Postico.pkg-receipt-20210213-225647.plist

The following packages were built:
    Identifier            Version  Pkg Path                                                                       
    ----------            -------  --------                                                                       
    at.eggerapps.Postico  1.5.17   ~/Library/AutoPkg/Cache/com.github.ygini.pkg.Postico/Postico.pkg  
```

