### PR TITLE
Correct Termius recipes

### DIFF
--- a/Termius/Termius.download.recipe
+++ b/Termius/Termius.download.recipe
@@ -3,13 +3,13 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>Download Terminus</string>
+    <string>Download Termius</string>
     <key>Identifier</key>
-    <string>com.github.ygini.download.terminus</string>
+    <string>com.github.ygini.download.termius</string>
     <key>Input</key>
     <dict>
         <key>NAME</key>
-        <string>terminus</string>
+        <string>termius</string>
     </dict>
     <key>MinimumVersion</key>
     <string>0.3.1</string>
@@ -21,7 +21,7 @@
                 <key>url</key>
                 <string>https://www.termi.us/mac-download</string>
                 <key>filename</key>
-                <string>terminus.dmg</string>
+                <string>termius.dmg</string>
             </dict>
             <key>Processor</key>
             <string>URLDownloader</string>

--- a/Termius/Termius.munki.recipe
+++ b/Termius/Termius.munki.recipe
@@ -3,15 +3,15 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>Download Terminus and publish it into Munki</string>
+    <string>Download Termius and publish it into Munki</string>
     <key>Identifier</key>
-    <string>com.github.ygini.munki.terminus</string>
+    <string>com.github.ygini.munki.termius</string>
     <key>MinimumVersion</key>
     <string>0.4.2</string>
     <key>Input</key>
     <dict>
         <key>NAME</key>
-        <string>terminus</string>
+        <string>termius</string>
 		<key>MUNKI_REPO_SUBDIR</key>
 		<string>it</string>
         <key>pkginfo</key>
@@ -31,11 +31,11 @@
 			<key>description</key>
 			<string>Termius is a portable server management system that works for you in any situation.</string>
 			<key>display_name</key>
-			<string>Terminus</string>
+			<string>Termius</string>
         </dict>
     </dict>
     <key>ParentRecipe</key>
-    <string>com.github.ygini.download.terminus</string>
+    <string>com.github.ygini.download.termius</string>
     <key>Process</key>
     <array>
         <dict>


### PR DESCRIPTION
Should be Termius and not Terminus.

Not sure if you want to handle this gracefully, or not.

Gracefully would be to have recipes with the same terminus identifiers as now.. but with https://github.com/autopkg/autopkg/wiki/Processor-DeprecationWarning point to the correctly named recipes.

Or.. not at all :)