### PR TITLE
Fix GlobalProtect Version number munkiimport

### DIFF
--- a/PaloAlto/GlobalProtectMac.munki.recipe
+++ b/PaloAlto/GlobalProtectMac.munki.recipe
@@ -84,6 +84,18 @@
 			<key>Processor</key>
 			<string>Versioner</string>
 		</dict>
+                <dict>
+                        <key>Arguments</key>
+                                <dict>
+                                        <key>additional_pkginfo</key>
+                                        <dict>
+                                                <key>version</key>
+                                                <string>%version%</string>
+                                        </dict>
+                                </dict>
+                        <key>Processor</key>
+                        <string>MunkiPkginfoMerger</string>
+                </dict>
 		<dict>
 			<key>Arguments</key>
 			<dict>


### PR DESCRIPTION
GlobalProtect version number always was 0.0 ... these Changes will pass through the version number and GlobalProtect will import to munch with the correct version number.