### PR TITLE
Mattermost: Fix regex and use new universal dmg

### DIFF
--- a/Mattermost/Mattermost.download.recipe
+++ b/Mattermost/Mattermost.download.recipe
@@ -33,7 +33,7 @@
                         <key>github_repo</key>
                         <string>mattermost/desktop</string>
                         <key>asset_regex</key>
-                        <string>mattermost-desktop-[0-9.]+-%os%.dmg</string>
+                        <string>mattermost-desktop-[0-9.]+-%os%-universal.dmg</string>
                 </dict>
                         <key>Processor</key>
                         <string>GitHubReleasesInfoProvider</string>


### PR DESCRIPTION
Release 5.x now includes an architecture suffix for macos DMGs. I propose to use the universal dmg. Not sure how this is supposed to work for non-mac use cases however. But then, they are broken because of the `.dmg` ending anyway.