### PR TITLE
Update AWS VPN Client.munki.recipe

### DIFF
--- a/AWS VPN Client/AWS VPN Client.munki.recipe
+++ b/AWS VPN Client/AWS VPN Client.munki.recipe
@@ -5,11 +5,15 @@
     <key>Comment</key>
     <string>Created with Recipe Robot v2.2.0 (https://github.com/homebysix/recipe-robot)</string>
     <key>Description</key>
-    <string>Downloads the latest version of AWS VPN Client and imports it into Munki.</string>
+    <string>Downloads the latest version of AWS VPN Client and imports it into Munki.
+
+Set the DERIVE_MIN_OS variable to a non-empty string to set the minimum_os_version via MunkiInstallsItemsCreator. This requires a minimum AutoPkg version of 2.7 please update if you're not already running it.</string>
     <key>Identifier</key>
     <string>com.github.ygini.munki.AWSVPNClient</string>
     <key>Input</key>
     <dict>
+    	<key>DERIVE_MIN_OS</key>
+        <string>YES</string>
         <key>MUNKI_REPO_SUBDIR</key>
         <string>apps/%NAME%</string>
         <key>NAME</key>
@@ -40,7 +44,7 @@
         </dict>
     </dict>
     <key>MinimumVersion</key>
-    <string>1.0.0</string>
+    <string>2.7</string>
     <key>ParentRecipe</key>
     <string>com.github.ygini.download.AWSVPNClient</string>
     <key>Process</key>
@@ -91,6 +95,8 @@
                 <array>
                     <string>/Applications/AWS VPN Client/AWS VPN Client.app</string>
                 </array>
+                <key>derive_minimum_os_version</key>
+                <string>%DERIVE_MIN_OS%</string>
             </dict>
             <key>Processor</key>
             <string>MunkiInstallsItemsCreator</string>


### PR DESCRIPTION
Hi, @ygini 

The AWS VPN Client Munki recipe currently doesn't set the `minimum_os_version` from the App's info.plist, and as such a default value of 10.5.0 is being set.

This PR adds in support for the new `derive_minimum_os_version` key in the `MunkiInstallsItemsCreator` processor. With this set the min_os_version becomes 10.10

This change requires AutoPkg version 2.7 or higher, if compatibility with older versions of AutoPkg is needed, the same result could be achieved with something like below.

```
        <dict>
            <key>Arguments</key>
            <dict>
                <key>info_path</key>
                <string>%RECIPE_CACHE_DIR%/Applications/APP_NAME.app</string>
                <key>plist_keys</key>
                <dict>
                    <key>LSMinimumSystemVersion</key>
                    <string>min_os_ver</string>
                </dict>
            </dict>
            <key>Processor</key>
            <string>PlistReader</string>
        </dict>
        <dict>
             <key>Arguments</key>
             <dict>
                <key>additional_pkginfo</key>
                <dict>
                    <key>minimum_os_version</key>
                    <string>%min_os_ver%</string>
                </dict>
            </dict>
            <key>Processor</key>
            <string>MunkiPkginfoMerger</string>
        </dict>
```

Output from a successful verbose run:

```
autopkg run -v /Users/paul/Documents/GitHub/AutoPkg\ Repos/ygini-recipes/AWS\ VPN\ Client/AWS\ VPN\ Client.munki.recipe 
Processing /Users/paul/Documents/GitHub/AutoPkg Repos/ygini-recipes/AWS VPN Client/AWS VPN Client.munki.recipe...
WARNING: /Users/paul/Documents/GitHub/AutoPkg Repos/ygini-recipes/AWS VPN Client/AWS VPN Client.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLDownloader
URLDownloader: Storing new Last-Modified header: Mon, 23 May 2022 21:37:30 GMT
URLDownloader: Storing new ETag header: "a28ed61d012263b47b800ec38a7630e5"
URLDownloader: Downloaded /Users/paul/Library/AutoPkg/Cache/com.github.ygini.munki.AWSVPNClient/downloads/AWS VPN Client.pkg
EndOfCheckPhase
CodeSignatureVerifier
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "AWS VPN Client.pkg":
CodeSignatureVerifier:    Status: signed by a developer certificate issued by Apple for distribution
CodeSignatureVerifier:    Notarization: trusted by the Apple notary service
CodeSignatureVerifier:    Signed with a trusted timestamp on: 2022-05-17 21:57:12 +0000
CodeSignatureVerifier:    Certificate Chain:
CodeSignatureVerifier:     1. Developer ID Installer: AMZN Mobile LLC (94KV3E626L)
CodeSignatureVerifier:        Expires: 2024-10-18 22:31:30 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            81 B4 6F AF 1C CA E1 E8 3C 6F FB 9E 52 5E 84 02 6E 7F 17 21 8E FB 
CodeSignatureVerifier:            0C 40 79 13 66 8D 9F 1F 10 1C
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     2. Developer ID Certification Authority
CodeSignatureVerifier:        Expires: 2027-02-01 22:12:15 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            7A FC 9D 01 A6 2F 03 A2 DE 96 37 93 6D 4A FE 68 09 0D 2D E1 8D 03 
CodeSignatureVerifier:            F2 9C 88 CF B0 B1 BA 63 58 7F
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     3. Apple Root CA
CodeSignatureVerifier:        Expires: 2035-02-09 21:40:36 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C 
CodeSignatureVerifier:            68 C5 BE 91 B5 A1 10 01 F0 24
CodeSignatureVerifier: 
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier: Authority name chain is valid
FlatPkgUnpacker
FlatPkgUnpacker: Unpacked /Users/paul/Library/AutoPkg/Cache/com.github.ygini.munki.AWSVPNClient/downloads/AWS VPN Client.pkg to /Users/paul/Library/AutoPkg/Cache/com.github.ygini.munki.AWSVPNClient/unpack
PkgPayloadUnpacker
PkgPayloadUnpacker: Unpacked /Users/paul/Library/AutoPkg/Cache/com.github.ygini.munki.AWSVPNClient/unpack/AWS_VPN_Client.pkg/payload to /Users/paul/Library/AutoPkg/Cache/com.github.ygini.munki.AWSVPNClient/Applications
Versioner
Versioner: Found version 3.1.0 in file /Users/paul/Library/AutoPkg/Cache/com.github.ygini.munki.AWSVPNClient/Applications/AWS VPN Client/AWS VPN Client.app/Contents/Info.plist
MunkiInstallsItemsCreator
MunkiInstallsItemsCreator: Created installs item for /Applications/AWS VPN Client/AWS VPN Client.app
MunkiInstallsItemsCreator: Derived minimum os version as: 10.10
MunkiPkginfoMerger
MunkiPkginfoMerger: Merged {'installs': [{'CFBundleIdentifier': 'com.amazonaws.acvc.osx', 'CFBundleName': 'AWS VPN Client', 'CFBundleShortVersionString': '3.1.0', 'CFBundleVersion': '3.1.0', 'minosversion': '10.10', 'path': '/Applications/AWS VPN Client/AWS VPN Client.app', 'type': 'application', 'version_comparison_key': 'CFBundleShortVersionString'}], 'minimum_os_version': '10.10'} into pkginfo
MunkiImporter
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/Shared/munki_repo
MunkiImporter: Copied pkginfo to: /Users/Shared/munki_repo/pkgsinfo/apps/AWS VPN Client/AWS VPN Client-3.1.0.plist
MunkiImporter:            pkg to: /Users/Shared/munki_repo/pkgs/apps/AWS VPN Client/AWS VPN Client-3.1.0.pkg
Receipt written to /Users/paul/Library/AutoPkg/Cache/com.github.ygini.munki.AWSVPNClient/receipts/AWS VPN Client.munki-receipt-20230106-133841.plist

The following new items were downloaded:
    Download Path                                                                                       
    -------------                                                                                       
    /Users/paul/Library/AutoPkg/Cache/com.github.ygini.munki.AWSVPNClient/downloads/AWS VPN Client.pkg  

The following new items were imported into Munki:
    Name            Version  Catalogs  Pkginfo Path                                    Pkg Repo Path                                 Icon Repo Path  
    ----            -------  --------  ------------                                    -------------                                 --------------  
    AWS VPN Client  3.1.0    testing   apps/AWS VPN Client/AWS VPN Client-3.1.0.plist  apps/AWS VPN Client/AWS VPN Client-3.1.0.pkg
```
