### PR TITLE
Update AWS VPN Client.munki.recipe

### DIFF
--- a/AWS VPN Client/AWS VPN Client.munki.recipe
+++ b/AWS VPN Client/AWS VPN Client.munki.recipe
@@ -51,7 +51,7 @@
             <key>destination_path</key>
             <string>%RECIPE_CACHE_DIR%/unpack</string>
             <key>flat_pkg_path</key>
-            <string>%RECIPE_CACHE_DIR%/downloads/AWS VPN Client.pkg</string>
+            <string>%RECIPE_CACHE_DIR%/downloads/%NAME%.pkg</string>
             <key>purge_destination</key>
             <true/>
         </dict>


### PR DESCRIPTION
Fixes the Munki recipe so that the `FlatPkgUnpacker` processor still works if the `NAME` variable is changed in the override.