### PR TITLE
Deprecate NoMachine.download and give NoMachine.munki a working parent

### DIFF
--- a/NoMachine/NoMachine.download.recipe
+++ b/NoMachine/NoMachine.download.recipe
@@ -17,6 +17,15 @@
     <array>
         <dict>
             <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>Consider switching to the NoMachine recipes in the novaksam-recipes repo. This recipe is deprecated and will be removed in the future.</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>URLTextSearcher</string>
             <key>Arguments</key>
             <dict>

--- a/NoMachine/NoMachine.munki.recipe
+++ b/NoMachine/NoMachine.munki.recipe
@@ -39,7 +39,7 @@
         </dict>
     </dict>
     <key>ParentRecipe</key>
-    <string>com.github.ygini.download.NoMachine</string>
+    <string>com.github.novaksam.download.NoMachine</string>
     <key>Process</key>
     <array>
         <dict>


### PR DESCRIPTION
This PR deprecates the non-functional NoMachine.download recipe, and switches the NoMachine.munki parent recipe to a working equivalent in novaksam-recipes.

Verbose munki recipe run output:

```
% autopkg run -vvq NoMachine.munki.recipe
Processing NoMachine.munki.recipe...
WARNING: NoMachine.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
{'Input': {'curl_opts': ['-b nomachine_cookies.txt -L'],
           're_pattern': '(https://.*nomachine_[0-9\\.\\_]+.dmg)',
           'url': 'https://downloads.nomachine.com/download/?id=7'}}
URLTextSearcher: No value supplied for result_output_var_name, setting default value of: match
URLTextSearcher: Found matching text (match): https://download.nomachine.com/download/8.14/MacOSX/nomachine_8.14.2_4.dmg
{'Output': {'match': 'https://download.nomachine.com/download/8.14/MacOSX/nomachine_8.14.2_4.dmg'}}
URLDownloader
{'Input': {'curl_opts': ['-b nomachine_cookies.txt -L'],
           'filename': 'nomachine.dmg',
           'url': 'https://download.nomachine.com/download/8.14/MacOSX/nomachine_8.14.2_4.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Tue, 01 Oct 2024 11:18:58 GMT
URLDownloader: Storing new ETag header: "66fbdaa2-4fe2aa1"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.ygini.munki.NoMachine/downloads/nomachine.dmg
{'Output': {'download_changed': True,
            'etag': '"66fbdaa2-4fe2aa1"',
            'last_modified': 'Tue, 01 Oct 2024 11:18:58 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.ygini.munki.NoMachine/downloads/nomachine.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.ygini.munki.NoMachine/downloads/nomachine.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
CodeSignatureVerifier
{'Input': {'expected_authority_names': ['Developer ID Installer: NoMachine '
                                        'S.a.r.l. (493C5JZAGR)',
                                        'Developer ID Certification Authority',
                                        'Apple Root CA'],
           'input_path': '~/Library/AutoPkg/Cache/com.github.ygini.munki.NoMachine/downloads/nomachine.dmg/*.pkg'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.ygini.munki.NoMachine/downloads/nomachine.dmg
CodeSignatureVerifier: Using path '/private/tmp/dmg.dh8yho/NoMachine.pkg' matched from globbed '/private/tmp/dmg.dh8yho/*.pkg'.
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "NoMachine.pkg":
CodeSignatureVerifier:    Status: signed by a developer certificate issued by Apple for distribution
CodeSignatureVerifier:    Notarization: trusted by the Apple notary service
CodeSignatureVerifier:    Signed with a trusted timestamp on: 2024-10-01 10:54:22 +0000
CodeSignatureVerifier:    Certificate Chain:
CodeSignatureVerifier:     1. Developer ID Installer: NoMachine S.a.r.l. (493C5JZAGR)
CodeSignatureVerifier:        Expires: 2028-03-07 17:36:15 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            3B DB 98 8C 54 57 11 8E CC 7D 95 55 0F 3B DF 83 A5 C7 EA B0 5E 34
CodeSignatureVerifier:            E4 EB 4F 85 0E 47 8D 2C CF 43
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     2. Developer ID Certification Authority
CodeSignatureVerifier:        Expires: 2031-09-17 00:00:00 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            F1 6C D3 C5 4C 7F 83 CE A4 BF 1A 3E 6A 08 19 C8 AA A8 E4 A1 52 8F
CodeSignatureVerifier:            D1 44 71 5F 35 06 43 D2 DF 3A
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     3. Apple Root CA
CodeSignatureVerifier:        Expires: 2035-02-09 21:40:36 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C
CodeSignatureVerifier:            68 C5 BE 91 B5 A1 10 01 F0 24
CodeSignatureVerifier:
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier: Authority name chain is valid
{'Output': {}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
MunkiImporter
{'Input': {'MUNKI_REPO': '/Users/Shared/munki_repo',
           'pkg_path': '~/Library/AutoPkg/Cache/com.github.ygini.munki.NoMachine/downloads/nomachine.dmg',
           'pkginfo': {'catalogs': ['testing'],
                       'category': 'Remote Access',
                       'description': 'Go from your desktop to any '
                                      'NoMachine-enabled computer at the speed '
                                      'of light. Thanks to our NX technology, '
                                      'NoMachine is the fastest and highest '
                                      'quality remote desktop you have ever '
                                      'tried. Get to any computer in the world '
                                      "in just a few clicks! Take what's "
                                      'important where you go and share with '
                                      'who you want! NoMachine is your own '
                                      'personal server, private and secure. '
                                      'Did we say NoMachine is free? No '
                                      'strings attached.',
                       'developer': 'NoMachine',
                       'display_name': 'NoMachine',
                       'name': 'nomachine',
                       'unattended_install': True},
           'repo_subdirectory': 'apps/nomachine'}}
MunkiImporter: No value supplied for MUNKI_REPO_PLUGIN, setting default value of: FileRepo
MunkiImporter: No value supplied for MUNKILIB_DIR, setting default value of: /usr/local/munki
MunkiImporter: No value supplied for force_munki_repo_lib, setting default value of: False
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/Shared/munki_repo
MunkiImporter: Copied pkginfo to: /Users/Shared/munki_repo/pkgsinfo/apps/nomachine/nomachine-0.0.plist
MunkiImporter:            pkg to: /Users/Shared/munki_repo/pkgs/apps/nomachine/nomachine-0.0.dmg
{'Output': {'munki_importer_summary_result': {'data': {'catalogs': 'testing',
                                                       'icon_repo_path': '',
                                                       'name': 'nomachine',
                                                       'pkg_repo_path': 'apps/nomachine/nomachine-0.0.dmg',
                                                       'pkginfo_path': 'apps/nomachine/nomachine-0.0.plist',
                                                       'version': '0.0'},
                                              'report_fields': ['name',
                                                                'version',
                                                                'catalogs',
                                                                'pkginfo_path',
                                                                'pkg_repo_path',
                                                                'icon_repo_path'],
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'imported into '
                                                              'Munki:'},
            'munki_info': {'_metadata': {'created_by': 'testuser',
                                         'creation_date': datetime.datetime(2024, 12, 28, 17, 16, 23),
                                         'munki_version': '6.6.3.4704',
                                         'os_version': '15.2'},
                           'autoremove': False,
                           'catalogs': ['testing'],
                           'category': 'Remote Access',
                           'description': 'Go from your desktop to any '
                                          'NoMachine-enabled computer at the '
                                          'speed of light. Thanks to our NX '
                                          'technology, NoMachine is the '
                                          'fastest and highest quality remote '
                                          'desktop you have ever tried. Get to '
                                          'any computer in the world in just a '
                                          "few clicks! Take what's important "
                                          'where you go and share with who you '
                                          'want! NoMachine is your own '
                                          'personal server, private and '
                                          'secure. Did we say NoMachine is '
                                          'free? No strings attached.',
                           'developer': 'NoMachine',
                           'display_name': 'NoMachine',
                           'installed_size': 226143,
                           'installer_item_hash': 'a35e1d43a4184a84024fb018ee617b09346c54c5940462b2618cbf738339c9f5',
                           'installer_item_location': 'apps/nomachine/nomachine-0.0.dmg',
                           'installer_item_size': 81802,
                           'minimum_os_version': '10.5.0',
                           'name': 'nomachine',
                           'receipts': [{'installed_size': 13415,
                                         'packageid': 'com.nomachine.nxserver',
                                         'version': '0'},
                                        {'installed_size': 37939,
                                         'packageid': 'com.nomachine.nxnode',
                                         'version': '0'},
                                        {'installed_size': 149614,
                                         'packageid': 'com.nomachine.nxrunner',
                                         'version': '0'},
                                        {'installed_size': 25175,
                                         'packageid': 'com.nomachine.nxplayer',
                                         'version': '0'}],
                           'unattended_install': True,
                           'uninstall_method': 'removepackages',
                           'uninstallable': True,
                           'version': '0.0'},
            'munki_repo_changed': True,
            'pkg_repo_path': '/Users/Shared/munki_repo/pkgs/apps/nomachine/nomachine-0.0.dmg',
            'pkginfo_repo_path': '/Users/Shared/munki_repo/pkgsinfo/apps/nomachine/nomachine-0.0.plist'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.ygini.munki.NoMachine/receipts/NoMachine.munki-receipt-20241228-091623.plist

The following new items were downloaded:
    Download Path
    -------------
    ~/Library/AutoPkg/Cache/com.github.ygini.munki.NoMachine/downloads/nomachine.dmg

The following new items were imported into Munki:
    Name       Version  Catalogs  Pkginfo Path                        Pkg Repo Path                     Icon Repo Path
    ----       -------  --------  ------------                        -------------                     --------------
    nomachine  0.0      testing   apps/nomachine/nomachine-0.0.plist  apps/nomachine/nomachine-0.0.dmg
```
