### PR TITLE
Deprecate RV64 recipes

### DIFF
--- a/RV64/RV64.download.recipe
+++ b/RV64/RV64.download.recipe
@@ -17,6 +17,15 @@
     <array>
         <dict>
             <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>Consider switching to the RV recipes in the homebysix-recipes repo. This recipe is deprecated and will be removed in the future.</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>URLTextSearcher</string>
             <key>Arguments</key>
             <dict>

--- a/RV64/RV64.download.recipe
+++ b/RV64/RV64.download.recipe
@@ -12,7 +12,7 @@
         <string>rv64</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.3.1</string>
+    <string>1.1</string>
     <key>Process</key>
     <array>
         <dict>


### PR DESCRIPTION
This PR deprecates the non-functional RV64 recipes, and points users to the working RV recipes in my homebysix-recipes repo.
