### PR TITLE
Fix Molotov.download recipe

### DIFF
--- a/Molotov/Molotov.download.recipe
+++ b/Molotov/Molotov.download.recipe
@@ -39,6 +39,21 @@
             <key>Processor</key>
             <string>EndOfCheckPhase</string>
         </dict>
+        <dict>
+            <key>Processor</key>
+            <string>Unarchiver</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>CodeSignatureVerifier</string>
+            <key>Arguments</key>
+            <dict>
+                <key>input_path</key>
+                <string>%RECIPE_CACHE_DIR%/%NAME%/Molotov.app</string>
+                <key>requirement</key>
+                <string>identifier "tv.molotov.MolotovDesktopApp" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = S7HY56XG6J</string>
+            </dict>
+        </dict>
     </array>
 </dict>
 </plist>

--- a/Molotov/Molotov.download.recipe
+++ b/Molotov/Molotov.download.recipe
@@ -23,14 +23,14 @@
                 <key>url</key>
                 <string>https://www.molotov.tv/app/mac/latest?version=v1</string>
                 <key>re_pattern</key>      
-                <string>http://desktop-auto-upgrade\.molotov\.tv/mac/Molotov-v(?P&lt;url_version_number&gt;.*?)-mac\.zip</string>
+                <string>https://desktop-auto-upgrade\.molotov\.tv/mac/Molotov-(?P&lt;url_version_number&gt;.*?)-mac\.zip</string>
             </dict>
         </dict>
         <dict>
             <key>Arguments</key>
             <dict>
                 <key>url</key>
-                <string>http://desktop-auto-upgrade.molotov.tv/mac/Molotov-v%url_version_number%-mac.zip</string>
+                <string>https://desktop-auto-upgrade.molotov.tv/mac/Molotov-%url_version_number%-mac.zip</string>
             </dict>
             <key>Processor</key>
             <string>URLDownloader</string>

--- a/Molotov/Molotov.munki.recipe
+++ b/Molotov/Molotov.munki.recipe
@@ -41,15 +41,6 @@
         <dict>
             <key>Arguments</key>
             <dict>
-                <key>archive_path</key>
-                <string>%pathname%</string>
-            </dict>
-            <key>Processor</key>
-            <string>Unarchiver</string>
-        </dict>
-        <dict>
-            <key>Arguments</key>
-            <dict>
                 <key>dmg_root</key>
                 <string>%RECIPE_CACHE_DIR%/%NAME%</string>
                 <key>dmg_path</key>

--- a/Molotov/Molotov.pkg.recipe
+++ b/Molotov/Molotov.pkg.recipe
@@ -20,17 +20,8 @@
         <dict>
             <key>Arguments</key>
             <dict>
-                <key>archive_path</key>
-                <string>%pathname%</string>
-            </dict>
-            <key>Processor</key>
-            <string>Unarchiver</string>
-        </dict>
-        <dict>
-            <key>Arguments</key>
-            <dict>
                 <key>app_path</key>
-                <string>%RECIPE_CACHE_DIR%/%NAME%/*.app</string>
+                <string>%RECIPE_CACHE_DIR%/%NAME%/Molotov.app</string>
             </dict>
             <key>Processor</key>
             <string>AppPkgCreator</string>


### PR DESCRIPTION
This PR fixes the download pattern for Molotov, and adds code signature verification.

Verbose recipe run output:

```
% autopkg run -vvq Molotov.*.recipe
Processing Molotov.download.recipe...
WARNING: Molotov.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
{'Input': {'re_pattern': 'https://desktop-auto-upgrade\\.molotov\\.tv/mac/Molotov-(?P<url_version_number>.*?)-mac\\.zip',
           'url': 'https://www.molotov.tv/app/mac/latest?version=v1'}}
URLTextSearcher: No value supplied for result_output_var_name, setting default value of: match
URLTextSearcher: Found matching text (url_version_number): 6.0.2
URLTextSearcher: Found matching text (match): 6.0.2
{'Output': {'match': '6.0.2', 'url_version_number': '6.0.2'}}
URLDownloader
{'Input': {'url': 'https://desktop-auto-upgrade.molotov.tv/mac/Molotov-6.0.2-mac.zip'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Tue, 27 Aug 2024 09:53:46 GMT
URLDownloader: Storing new ETag header: "62dd47622deac71784c4aa3e08ed15d0-13"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.ygini.download.Molotov/downloads/Molotov-6.0.2-mac.zip
{'Output': {'download_changed': True,
            'etag': '"62dd47622deac71784c4aa3e08ed15d0-13"',
            'last_modified': 'Tue, 27 Aug 2024 09:53:46 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.ygini.download.Molotov/downloads/Molotov-6.0.2-mac.zip',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.ygini.download.Molotov/downloads/Molotov-6.0.2-mac.zip'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Unarchiver
{'Input': {}}
Unarchiver: No value supplied for USE_PYTHON_NATIVE_EXTRACTOR, setting default value of: False
Unarchiver: Guessed archive format 'zip' from filename Molotov-6.0.2-mac.zip
Unarchiver: Unarchived ~/Library/AutoPkg/Cache/com.github.ygini.download.Molotov/downloads/Molotov-6.0.2-mac.zip to ~/Library/AutoPkg/Cache/com.github.ygini.download.Molotov/Molotov
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.ygini.download.Molotov/Molotov/Molotov.app',
           'requirement': 'identifier "tv.molotov.MolotovDesktopApp" and '
                          'anchor apple generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          'S7HY56XG6J'}}
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.ygini.download.Molotov/Molotov/Molotov.app: valid on disk
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.ygini.download.Molotov/Molotov/Molotov.app: satisfies its Designated Requirement
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.ygini.download.Molotov/Molotov/Molotov.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.ygini.download.Molotov/receipts/Molotov.download-receipt-20241228-082110.plist
Processing Molotov.munki.recipe...
WARNING: Molotov.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
{'Input': {'re_pattern': 'https://desktop-auto-upgrade\\.molotov\\.tv/mac/Molotov-(?P<url_version_number>.*?)-mac\\.zip',
           'url': 'https://www.molotov.tv/app/mac/latest?version=v1'}}
URLTextSearcher: No value supplied for result_output_var_name, setting default value of: match
URLTextSearcher: Found matching text (url_version_number): 6.0.2
URLTextSearcher: Found matching text (match): 6.0.2
{'Output': {'match': '6.0.2', 'url_version_number': '6.0.2'}}
URLDownloader
{'Input': {'url': 'https://desktop-auto-upgrade.molotov.tv/mac/Molotov-6.0.2-mac.zip'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Tue, 27 Aug 2024 09:53:46 GMT
URLDownloader: Storing new ETag header: "62dd47622deac71784c4aa3e08ed15d0-13"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.ygini.munki.Molotov/downloads/Molotov-6.0.2-mac.zip
{'Output': {'download_changed': True,
            'etag': '"62dd47622deac71784c4aa3e08ed15d0-13"',
            'last_modified': 'Tue, 27 Aug 2024 09:53:46 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.ygini.munki.Molotov/downloads/Molotov-6.0.2-mac.zip',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.ygini.munki.Molotov/downloads/Molotov-6.0.2-mac.zip'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Unarchiver
{'Input': {}}
Unarchiver: No value supplied for USE_PYTHON_NATIVE_EXTRACTOR, setting default value of: False
Unarchiver: Guessed archive format 'zip' from filename Molotov-6.0.2-mac.zip
Unarchiver: Unarchived ~/Library/AutoPkg/Cache/com.github.ygini.munki.Molotov/downloads/Molotov-6.0.2-mac.zip to ~/Library/AutoPkg/Cache/com.github.ygini.munki.Molotov/Molotov
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.ygini.munki.Molotov/Molotov/Molotov.app',
           'requirement': 'identifier "tv.molotov.MolotovDesktopApp" and '
                          'anchor apple generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          'S7HY56XG6J'}}
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.ygini.munki.Molotov/Molotov/Molotov.app: valid on disk
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.ygini.munki.Molotov/Molotov/Molotov.app: satisfies its Designated Requirement
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.ygini.munki.Molotov/Molotov/Molotov.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
DmgCreator
{'Input': {'dmg_path': '~/Library/AutoPkg/Cache/com.github.ygini.munki.Molotov/Molotov.dmg',
           'dmg_root': '~/Library/AutoPkg/Cache/com.github.ygini.munki.Molotov/Molotov'}}
DmgCreator: Created dmg from ~/Library/AutoPkg/Cache/com.github.ygini.munki.Molotov/Molotov at ~/Library/AutoPkg/Cache/com.github.ygini.munki.Molotov/Molotov.dmg
{'Output': {}}
MunkiImporter
{'Input': {'MUNKI_REPO': '/Users/Shared/munki_repo',
           'pkg_path': '~/Library/AutoPkg/Cache/com.github.ygini.munki.Molotov/Molotov.dmg',
           'pkginfo': {'catalogs': ['testing'],
                       'category': 'Entertainment',
                       'description': 'Une façon radicalement nouvelle de '
                                      'regarder la télévision. Gratuitement.',
                       'developer': 'Molotov',
                       'display_name': 'Molotov.tv',
                       'name': 'Molotov',
                       'unattended_install': True},
           'repo_subdirectory': 'apps/molotov'}}
MunkiImporter: No value supplied for MUNKI_REPO_PLUGIN, setting default value of: FileRepo
MunkiImporter: No value supplied for MUNKILIB_DIR, setting default value of: /usr/local/munki
MunkiImporter: No value supplied for force_munki_repo_lib, setting default value of: False
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/Shared/munki_repo
MunkiImporter: Copied pkginfo to: /Users/Shared/munki_repo/pkgsinfo/apps/molotov/Molotov-6.0.2.plist
MunkiImporter:            pkg to: /Users/Shared/munki_repo/pkgs/apps/molotov/Molotov-6.0.2.dmg
{'Output': {'munki_importer_summary_result': {'data': {'catalogs': 'testing',
                                                       'icon_repo_path': '',
                                                       'name': 'Molotov',
                                                       'pkg_repo_path': 'apps/molotov/Molotov-6.0.2.dmg',
                                                       'pkginfo_path': 'apps/molotov/Molotov-6.0.2.plist',
                                                       'version': '6.0.2'},
                                              'report_fields': ['name',
                                                                'version',
                                                                'catalogs',
                                                                'pkginfo_path',
                                                                'pkg_repo_path',
                                                                'icon_repo_path'],
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'imported into '
                                                              'Munki:'},
            'munki_info': {'_metadata': {'created_by': 'testuser',
                                         'creation_date': datetime.datetime(2024, 12, 28, 16, 21, 37),
                                         'munki_version': '6.6.3.4704',
                                         'os_version': '15.2'},
                           'autoremove': False,
                           'catalogs': ['testing'],
                           'category': 'Entertainment',
                           'description': 'Une façon radicalement nouvelle de '
                                          'regarder la télévision. '
                                          'Gratuitement.',
                           'developer': 'Molotov',
                           'display_name': 'Molotov.tv',
                           'installer_item_hash': '5ec7de10d1233d83e23f6f751ca0aebf8a0fe50311de2fba66814064fb420313',
                           'installer_item_location': 'apps/molotov/Molotov-6.0.2.dmg',
                           'installer_item_size': 104902,
                           'installer_type': 'copy_from_dmg',
                           'installs': [{'CFBundleIdentifier': 'tv.molotov.MolotovDesktopApp',
                                         'CFBundleName': 'Molotov',
                                         'CFBundleShortVersionString': '6.0.2',
                                         'CFBundleVersion': '6.0.2',
                                         'minosversion': '10.15',
                                         'path': '/Applications/Molotov.app',
                                         'type': 'application',
                                         'version_comparison_key': 'CFBundleShortVersionString'}],
                           'items_to_copy': [{'destination_path': '/Applications',
                                              'source_item': 'Molotov.app'}],
                           'minimum_os_version': '10.15',
                           'name': 'Molotov',
                           'unattended_install': True,
                           'uninstall_method': 'remove_copied_items',
                           'uninstallable': True,
                           'version': '6.0.2'},
            'munki_repo_changed': True,
            'pkg_repo_path': '/Users/Shared/munki_repo/pkgs/apps/molotov/Molotov-6.0.2.dmg',
            'pkginfo_repo_path': '/Users/Shared/munki_repo/pkgsinfo/apps/molotov/Molotov-6.0.2.plist'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.ygini.munki.Molotov/receipts/Molotov.munki-receipt-20241228-082137.plist
Processing Molotov.pkg.recipe...
WARNING: Molotov.pkg.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
{'Input': {'re_pattern': 'https://desktop-auto-upgrade\\.molotov\\.tv/mac/Molotov-(?P<url_version_number>.*?)-mac\\.zip',
           'url': 'https://www.molotov.tv/app/mac/latest?version=v1'}}
URLTextSearcher: No value supplied for result_output_var_name, setting default value of: match
URLTextSearcher: Found matching text (url_version_number): 6.0.2
URLTextSearcher: Found matching text (match): 6.0.2
{'Output': {'match': '6.0.2', 'url_version_number': '6.0.2'}}
URLDownloader
{'Input': {'url': 'https://desktop-auto-upgrade.molotov.tv/mac/Molotov-6.0.2-mac.zip'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Tue, 27 Aug 2024 09:53:46 GMT
URLDownloader: Storing new ETag header: "62dd47622deac71784c4aa3e08ed15d0-13"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.ygini.pkg.Molotov/downloads/Molotov-6.0.2-mac.zip
{'Output': {'download_changed': True,
            'etag': '"62dd47622deac71784c4aa3e08ed15d0-13"',
            'last_modified': 'Tue, 27 Aug 2024 09:53:46 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.ygini.pkg.Molotov/downloads/Molotov-6.0.2-mac.zip',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.ygini.pkg.Molotov/downloads/Molotov-6.0.2-mac.zip'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Unarchiver
{'Input': {}}
Unarchiver: No value supplied for USE_PYTHON_NATIVE_EXTRACTOR, setting default value of: False
Unarchiver: Guessed archive format 'zip' from filename Molotov-6.0.2-mac.zip
Unarchiver: Unarchived ~/Library/AutoPkg/Cache/com.github.ygini.pkg.Molotov/downloads/Molotov-6.0.2-mac.zip to ~/Library/AutoPkg/Cache/com.github.ygini.pkg.Molotov/Molotov
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.ygini.pkg.Molotov/Molotov/Molotov.app',
           'requirement': 'identifier "tv.molotov.MolotovDesktopApp" and '
                          'anchor apple generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          'S7HY56XG6J'}}
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.ygini.pkg.Molotov/Molotov/Molotov.app: valid on disk
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.ygini.pkg.Molotov/Molotov/Molotov.app: satisfies its Designated Requirement
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.ygini.pkg.Molotov/Molotov/Molotov.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
AppPkgCreator
{'Input': {'app_path': '~/Library/AutoPkg/Cache/com.github.ygini.pkg.Molotov/Molotov/Molotov.app'}}
AppPkgCreator: Version: 6.0.2
AppPkgCreator: BundleID: tv.molotov.MolotovDesktopApp
AppPkgCreator: Copied ~/Library/AutoPkg/Cache/com.github.ygini.pkg.Molotov/Molotov/Molotov.app to ~/Library/AutoPkg/Cache/com.github.ygini.pkg.Molotov/payload/Applications/Molotov.app
AppPkgCreator: Connecting
AppPkgCreator: Sending packaging request
AppPkgCreator: Disconnecting
AppPkgCreator: Failed to close socket: [Errno 9] Bad file descriptor
{'Output': {'app_pkg_creator_summary_result': {'data': {'identifier': 'tv.molotov.MolotovDesktopApp',
                                                        'pkg_path': '~/Library/AutoPkg/Cache/com.github.ygini.pkg.Molotov/Molotov-6.0.2.pkg',
                                                        'version': '6.0.2'},
                                               'report_fields': ['identifier',
                                                                 'version',
                                                                 'pkg_path'],
                                               'summary_text': 'The following '
                                                               'packages were '
                                                               'built:'},
            'new_package_request': True,
            'version': '6.0.2'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.ygini.pkg.Molotov/receipts/Molotov.pkg-receipt-20241228-082152.plist

The following new items were downloaded:
    Download Path
    -------------
    ~/Library/AutoPkg/Cache/com.github.ygini.download.Molotov/downloads/Molotov-6.0.2-mac.zip
    ~/Library/AutoPkg/Cache/com.github.ygini.munki.Molotov/downloads/Molotov-6.0.2-mac.zip
    ~/Library/AutoPkg/Cache/com.github.ygini.pkg.Molotov/downloads/Molotov-6.0.2-mac.zip

The following new items were imported into Munki:
    Name     Version  Catalogs  Pkginfo Path                      Pkg Repo Path                   Icon Repo Path
    ----     -------  --------  ------------                      -------------                   --------------
    Molotov  6.0.2    testing   apps/molotov/Molotov-6.0.2.plist  apps/molotov/Molotov-6.0.2.dmg

The following packages were built:
    Identifier                    Version  Pkg Path
    ----------                    -------  --------
    tv.molotov.MolotovDesktopApp  6.0.2    ~/Library/AutoPkg/Cache/com.github.ygini.pkg.Molotov/Molotov-6.0.2.pkg
```
