### PR TITLE
Deprecate iTaskX 3 recipes

### DIFF
--- a/Techno-Grafik Christian Lackner eU/iTaskX3.download.recipe
+++ b/Techno-Grafik Christian Lackner eU/iTaskX3.download.recipe
@@ -16,9 +16,18 @@
 		<string>https://www.itaskx3.com/services/appcast.ashx</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.0</string>
+	<string>1.1</string>
 	<key>Process</key>
 	<array>
+		<dict>
+			<key>Processor</key>
+			<string>DeprecationWarning</string>
+			<key>Arguments</key>
+			<dict>
+				<key>warning_message</key>
+				<string>Consider switching to the iTaskX recipes in the andredb90-recipes or zentral-recipes repos. This recipe is deprecated and will be removed in the future.</string>
+			</dict>
+		</dict>
 		<dict>
 			<key>Arguments</key>
 			<dict>


### PR DESCRIPTION
This PR deprecates the iTaskX 3 recipes, since the software is no longer available to download. Users are directed to working iTaskX 4 recipes in the andredb90-recipes or zentral-recipes repos.

