### PR TITLE
Deprecate FileMaker recipes

### DIFF
--- a/FileMaker14/FileMaker14Updater.download.recipe
+++ b/FileMaker14/FileMaker14Updater.download.recipe
@@ -12,9 +12,18 @@
         <string>FileMaker14Updater</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.3.1</string>
+    <string>1.1</string>
     <key>Process</key>
     <array>
+        <dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>FileMaker 14 is no longer supported (details: https://support.claris.com/s/article/FileMaker-announces-the-end-of-support-for-FileMaker-14-Platform). This recipe is deprecated and will be removed in the future.</string>
+            </dict>
+        </dict>
         <dict>
             <key>Processor</key>
             <string>URLTextSearcher</string>

--- a/FileMaker15/FileMaker15Updater.download.recipe
+++ b/FileMaker15/FileMaker15Updater.download.recipe
@@ -12,9 +12,18 @@
         <string>FileMaker15Updater</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.3.1</string>
+    <string>1.1</string>
     <key>Process</key>
     <array>
+        <dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>FileMaker 15 is no longer supported (details: https://support.claris.com/s/article/FileMaker-Announces-end-of-support-for-FileMaker-15-Platform). This recipe is deprecated and will be removed in the future.</string>
+            </dict>
+        </dict>
         <dict>
             <key>Processor</key>
             <string>URLTextSearcher</string>

--- a/FileMaker16/FileMaker16Updater.download.recipe
+++ b/FileMaker16/FileMaker16Updater.download.recipe
@@ -12,9 +12,18 @@
         <string>FileMaker16Updater</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.3.1</string>
+    <string>1.1</string>
     <key>Process</key>
     <array>
+        <dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>FileMaker 16 is no longer supported (details: https://support.claris.com/s/article/Claris-support-policy). This recipe is deprecated and will be removed in the future.</string>
+            </dict>
+        </dict>
         <dict>
             <key>Processor</key>
             <string>URLTextSearcher</string>


### PR DESCRIPTION
This PR deprecates end-of-life FileMaker download recipes. Details to Claris support announcements are provided in the deprecation warning message.
