### PR TITLE
Fix Elgato Video Capture recipes

### DIFF
--- a/Elgato Systems GmbH/Elgato Video Capture.download.recipe
+++ b/Elgato Systems GmbH/Elgato Video Capture.download.recipe
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>Comment</key>
-	<string>Created with Recipe Robot v1.0.1 (https://github.com/homebysix/recipe-robot)</string>
+	<string>Created with Recipe Robot v2.3.1 (https://github.com/homebysix/recipe-robot)</string>
 	<key>Description</key>
 	<string>Downloads the latest version of Elgato Video Capture.</string>
 	<key>Identifier</key>
@@ -14,23 +14,32 @@
 		<string>Elgato Video Capture</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.0</string>
+	<string>2.3</string>
 	<key>Process</key>
 	<array>
-	    <dict>
-            <key>Processor</key>
-            <string>SparkleUpdateInfoProvider</string>
-            <key>Arguments</key>
-            <dict>
-                <key>appcast_url</key>
-                <string>http://updates.elgato.com/autoupdate/videoCapture.rss</string>
-            </dict>
-        </dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>re_pattern</key>
+				<string>href="(https://edge\.elgato\.com/video-capture/macos/[\d\.]+/Video_Capture_(?P&lt;version&gt;[\d\.]+)\.zip)"</string>
+				<key>result_output_var_name</key>
+				<string>url</string>
+				<key>url</key>
+				<string>https://help.elgato.com/hc/en-us/articles/360028243991-Elgato-Video-Capture-Software-Release-Notes</string>
+				<key>request_headers</key>
+				<dict>
+					<key>User-Agent</key>
+					<string>Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36</string>
+				</dict>
+			</dict>
+			<key>Processor</key>
+			<string>URLTextSearcher</string>
+		</dict>
 		<dict>
 			<key>Arguments</key>
 			<dict>
 				<key>filename</key>
-				<string>%NAME%.dmg</string>
+				<string>%NAME%-%version%.zip</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>
@@ -40,21 +49,39 @@
 			<string>EndOfCheckPhase</string>
 		</dict>
 		<dict>
-			<key>Processor</key>
-			<string>URLTextSearcher</string>
 			<key>Arguments</key>
 			<dict>
-				<key>url</key>
-				<string>http://updates.elgato.com/autoupdate/videoCapture.rss</string>
-				<key>result_output_var_name</key>
-				<string>version</string>
-				<key>re_pattern</key>
-				<string>Elgato Video Capture (\d\.\d\.\d)</string>
-				<key>re_flags</key>
-				<array>
-					<string>IGNORECASE</string>
-				</array>
+				<key>archive_path</key>
+				<string>%pathname%</string>
+				<key>destination_path</key>
+				<string>%RECIPE_CACHE_DIR%/%NAME%</string>
+				<key>purge_destination</key>
+				<true/>
 			</dict>
+			<key>Processor</key>
+			<string>Unarchiver</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>input_path</key>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Elgato Video Capture.app</string>
+				<key>requirement</key>
+				<string>anchor apple generic and identifier "com.elgato.VideoCapture" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = Y93VXCB8Q5)</string>
+			</dict>
+			<key>Processor</key>
+			<string>CodeSignatureVerifier</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>input_plist_path</key>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Elgato Video Capture.app/Contents/Info.plist</string>
+				<key>plist_version_key</key>
+				<string>CFBundleShortVersionString</string>
+			</dict>
+			<key>Processor</key>
+			<string>Versioner</string>
 		</dict>
 	</array>
 </dict>

--- a/Elgato Systems GmbH/Elgato Video Capture.install.recipe
+++ b/Elgato Systems GmbH/Elgato Video Capture.install.recipe
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>Comment</key>
-	<string>Created with Recipe Robot v1.0.1 (https://github.com/homebysix/recipe-robot)</string>
+	<string>Created with Recipe Robot v2.3.1 (https://github.com/homebysix/recipe-robot)</string>
 	<key>Description</key>
 	<string>Installs the latest version of Elgato Video Capture.</string>
 	<key>Identifier</key>
@@ -14,7 +14,7 @@
 		<string>Elgato Video Capture</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.0</string>
+	<string>2.3</string>
 	<key>ParentRecipe</key>
 	<string>com.github.ygini.download.ElgatoVideoCapture</string>
 	<key>Process</key>
@@ -23,7 +23,18 @@
 			<key>Arguments</key>
 			<dict>
 				<key>dmg_path</key>
-				<string>%pathname%</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%.dmg</string>
+				<key>dmg_root</key>
+				<string>%RECIPE_CACHE_DIR%/%NAME%</string>
+			</dict>
+			<key>Processor</key>
+			<string>DmgCreator</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>dmg_path</key>
+				<string>%dmg_path%</string>
 				<key>items_to_copy</key>
 				<array>
 					<dict>

--- a/Elgato Systems GmbH/Elgato Video Capture.munki.recipe
+++ b/Elgato Systems GmbH/Elgato Video Capture.munki.recipe
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>Comment</key>
-	<string>Created with Recipe Robot v1.0.1 (https://github.com/homebysix/recipe-robot)</string>
+	<string>Created with Recipe Robot v2.3.1 (https://github.com/homebysix/recipe-robot)</string>
 	<key>Description</key>
 	<string>Downloads the latest version of Elgato Video Capture and imports it into Munki.</string>
 	<key>Identifier</key>
@@ -35,7 +35,7 @@
 		</dict>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.0</string>
+	<string>2.3</string>
 	<key>ParentRecipe</key>
 	<string>com.github.ygini.download.ElgatoVideoCapture</string>
 	<key>Process</key>
@@ -43,8 +43,19 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
+				<key>dmg_path</key>
+				<string>%RECIPE_CACHE_DIR%/%NAME%.dmg</string>
+				<key>dmg_root</key>
+				<string>%RECIPE_CACHE_DIR%/%NAME%</string>
+			</dict>
+			<key>Processor</key>
+			<string>DmgCreator</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
 				<key>pkg_path</key>
-				<string>%pathname%</string>
+				<string>%dmg_path%</string>
 				<key>repo_subdirectory</key>
 				<string>%MUNKI_REPO_SUBDIR%</string>
 			</dict>

--- a/Elgato Systems GmbH/Elgato Video Capture.pkg.recipe
+++ b/Elgato Systems GmbH/Elgato Video Capture.pkg.recipe
@@ -3,20 +3,18 @@
 <plist version="1.0">
 <dict>
 	<key>Comment</key>
-	<string>Created with Recipe Robot v1.0.1 (https://github.com/homebysix/recipe-robot)</string>
+	<string>Created with Recipe Robot v2.3.1 (https://github.com/homebysix/recipe-robot)</string>
 	<key>Description</key>
 	<string>Downloads the latest version of Elgato Video Capture and creates a package.</string>
 	<key>Identifier</key>
 	<string>com.github.ygini.pkg.ElgatoVideoCapture</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.elgato.VideoCapture</string>
 		<key>NAME</key>
 		<string>Elgato Video Capture</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.0</string>
+	<string>2.3</string>
 	<key>ParentRecipe</key>
 	<string>com.github.ygini.download.ElgatoVideoCapture</string>
 	<key>Process</key>
@@ -24,58 +22,11 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>pkgdirs</key>
-				<dict>
-					<key>Applications</key>
-					<string>0775</string>
-				</dict>
-				<key>pkgroot</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%</string>
+				<key>app_path</key>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Elgato Video Capture.app</string>
 			</dict>
 			<key>Processor</key>
-			<string>PkgRootCreator</string>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>destination_path</key>
-				<string>%pkgroot%/Applications/Elgato Video Capture.app</string>
-				<key>source_path</key>
-				<string>%pathname%/Elgato Video Capture.app</string>
-			</dict>
-			<key>Processor</key>
-			<string>Copier</string>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>pkg_request</key>
-				<dict>
-					<key>chown</key>
-					<array>
-						<dict>
-							<key>group</key>
-							<string>admin</string>
-							<key>path</key>
-							<string>Applications</string>
-							<key>user</key>
-							<string>root</string>
-						</dict>
-					</array>
-					<key>id</key>
-					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
-					<key>pkgname</key>
-					<string>%NAME%-%version%</string>
-					<key>pkgroot</key>
-					<string>%RECIPE_CACHE_DIR%/%NAME%</string>
-					<key>version</key>
-					<string>%version%</string>
-				</dict>
-			</dict>
-			<key>Processor</key>
-			<string>PkgCreator</string>
+			<string>AppPkgCreator</string>
 		</dict>
 	</array>
 </dict>


### PR DESCRIPTION
This PR reworks the Elgato Video Capture recipes because the old Sparkle feed is now offline. Instead, we use URLTextSearcher to determine the latest version's download URL. The download is now in zip format, so child recipes needed adjustment for that change.

Verbose recipe run output for download, munki, and pkg recipes:

```
% autopkg run -vv Elgato\ Video\ Capture.{download,pkg,munki}.recipe
Processing Elgato Video Capture.download.recipe...
WARNING: Elgato Video Capture.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
{'Input': {'re_pattern': 'href="(https://edge\\.elgato\\.com/video-capture/macos/[\\d\\.]+/Video_Capture_(?P<version>[\\d\\.]+)\\.zip)"',
           'request_headers': {'User-Agent': 'Mozilla/5.0 (Macintosh; Intel '
                                             'Mac OS X 10_15_7) '
                                             'AppleWebKit/537.36 (KHTML, like '
                                             'Gecko) Chrome/131.0.0.0 '
                                             'Safari/537.36'},
           'result_output_var_name': 'url',
           'url': 'https://help.elgato.com/hc/en-us/articles/360028243991-Elgato-Video-Capture-Software-Release-Notes'}}
URLTextSearcher: Found matching text (version): 2.0.9.8722
URLTextSearcher: Found matching text (url): https://edge.elgato.com/video-capture/macos/2.0.9/Video_Capture_2.0.9.8722.zip
{'Output': {'url': 'https://edge.elgato.com/video-capture/macos/2.0.9/Video_Capture_2.0.9.8722.zip',
            'version': '2.0.9.8722'}}
URLDownloader
{'Input': {'filename': 'Elgato Video Capture-2.0.9.8722.zip',
           'request_headers': {'User-Agent': 'Mozilla/5.0 (Macintosh; Intel '
                                             'Mac OS X 10_15_7) '
                                             'AppleWebKit/537.36 (KHTML, like '
                                             'Gecko) Chrome/131.0.0.0 '
                                             'Safari/537.36'},
           'url': 'https://edge.elgato.com/video-capture/macos/2.0.9/Video_Capture_2.0.9.8722.zip'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Mon, 21 Oct 2024 15:50:12 GMT
URLDownloader: Storing new ETag header: "a2c54aebbc3b7822b7f303da76dc6d3a"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.ygini.download.ElgatoVideoCapture/downloads/Elgato Video Capture-2.0.9.8722.zip
{'Output': {'download_changed': True,
            'etag': '"a2c54aebbc3b7822b7f303da76dc6d3a"',
            'last_modified': 'Mon, 21 Oct 2024 15:50:12 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.ygini.download.ElgatoVideoCapture/downloads/Elgato '
                        'Video Capture-2.0.9.8722.zip',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.ygini.download.ElgatoVideoCapture/downloads/Elgato '
                                                                        'Video '
                                                                        'Capture-2.0.9.8722.zip'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Unarchiver
{'Input': {'archive_path': '~/Library/AutoPkg/Cache/com.github.ygini.download.ElgatoVideoCapture/downloads/Elgato '
                           'Video Capture-2.0.9.8722.zip',
           'destination_path': '~/Library/AutoPkg/Cache/com.github.ygini.download.ElgatoVideoCapture/Elgato '
                               'Video Capture',
           'purge_destination': True}}
Unarchiver: No value supplied for USE_PYTHON_NATIVE_EXTRACTOR, setting default value of: False
Unarchiver: Guessed archive format 'zip' from filename Elgato Video Capture-2.0.9.8722.zip
Unarchiver: Unarchived ~/Library/AutoPkg/Cache/com.github.ygini.download.ElgatoVideoCapture/downloads/Elgato Video Capture-2.0.9.8722.zip to ~/Library/AutoPkg/Cache/com.github.ygini.download.ElgatoVideoCapture/Elgato Video Capture
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.ygini.download.ElgatoVideoCapture/Elgato '
                         'Video Capture/Elgato Video Capture.app',
           'requirement': 'anchor apple generic and identifier '
                          '"com.elgato.VideoCapture" and (certificate '
                          'leaf[field.1.2.840.113635.100.6.1.9] /* exists */ '
                          'or certificate 1[field.1.2.840.113635.100.6.2.6] /* '
                          'exists */ and certificate '
                          'leaf[field.1.2.840.113635.100.6.1.13] /* exists */ '
                          'and certificate leaf[subject.OU] = Y93VXCB8Q5)'}}
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.ygini.download.ElgatoVideoCapture/Elgato Video Capture/Elgato Video Capture.app: valid on disk
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.ygini.download.ElgatoVideoCapture/Elgato Video Capture/Elgato Video Capture.app: satisfies its Designated Requirement
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.ygini.download.ElgatoVideoCapture/Elgato Video Capture/Elgato Video Capture.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Versioner
{'Input': {'input_plist_path': '~/Library/AutoPkg/Cache/com.github.ygini.download.ElgatoVideoCapture/Elgato '
                               'Video Capture/Elgato Video '
                               'Capture.app/Contents/Info.plist',
           'plist_version_key': 'CFBundleShortVersionString'}}
Versioner: No value supplied for skip_single_root_dir, setting default value of: False
Versioner: Found version 2.0.9 (8722) in file ~/Library/AutoPkg/Cache/com.github.ygini.download.ElgatoVideoCapture/Elgato Video Capture/Elgato Video Capture.app/Contents/Info.plist
{'Output': {'version': '2.0.9 (8722)'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.ygini.download.ElgatoVideoCapture/receipts/Elgato Video Capture.download-receipt-20241228-075747.plist
Processing Elgato Video Capture.pkg.recipe...
WARNING: Elgato Video Capture.pkg.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
{'Input': {'re_pattern': 'href="(https://edge\\.elgato\\.com/video-capture/macos/[\\d\\.]+/Video_Capture_(?P<version>[\\d\\.]+)\\.zip)"',
           'request_headers': {'User-Agent': 'Mozilla/5.0 (Macintosh; Intel '
                                             'Mac OS X 10_15_7) '
                                             'AppleWebKit/537.36 (KHTML, like '
                                             'Gecko) Chrome/131.0.0.0 '
                                             'Safari/537.36'},
           'result_output_var_name': 'url',
           'url': 'https://help.elgato.com/hc/en-us/articles/360028243991-Elgato-Video-Capture-Software-Release-Notes'}}
URLTextSearcher: Found matching text (version): 2.0.9.8722
URLTextSearcher: Found matching text (url): https://edge.elgato.com/video-capture/macos/2.0.9/Video_Capture_2.0.9.8722.zip
{'Output': {'url': 'https://edge.elgato.com/video-capture/macos/2.0.9/Video_Capture_2.0.9.8722.zip',
            'version': '2.0.9.8722'}}
URLDownloader
{'Input': {'filename': 'Elgato Video Capture-2.0.9.8722.zip',
           'request_headers': {'User-Agent': 'Mozilla/5.0 (Macintosh; Intel '
                                             'Mac OS X 10_15_7) '
                                             'AppleWebKit/537.36 (KHTML, like '
                                             'Gecko) Chrome/131.0.0.0 '
                                             'Safari/537.36'},
           'url': 'https://edge.elgato.com/video-capture/macos/2.0.9/Video_Capture_2.0.9.8722.zip'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Mon, 21 Oct 2024 15:50:12 GMT
URLDownloader: Storing new ETag header: "a2c54aebbc3b7822b7f303da76dc6d3a"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.ygini.pkg.ElgatoVideoCapture/downloads/Elgato Video Capture-2.0.9.8722.zip
{'Output': {'download_changed': True,
            'etag': '"a2c54aebbc3b7822b7f303da76dc6d3a"',
            'last_modified': 'Mon, 21 Oct 2024 15:50:12 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.ygini.pkg.ElgatoVideoCapture/downloads/Elgato '
                        'Video Capture-2.0.9.8722.zip',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.ygini.pkg.ElgatoVideoCapture/downloads/Elgato '
                                                                        'Video '
                                                                        'Capture-2.0.9.8722.zip'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Unarchiver
{'Input': {'archive_path': '~/Library/AutoPkg/Cache/com.github.ygini.pkg.ElgatoVideoCapture/downloads/Elgato '
                           'Video Capture-2.0.9.8722.zip',
           'destination_path': '~/Library/AutoPkg/Cache/com.github.ygini.pkg.ElgatoVideoCapture/Elgato '
                               'Video Capture',
           'purge_destination': True}}
Unarchiver: No value supplied for USE_PYTHON_NATIVE_EXTRACTOR, setting default value of: False
Unarchiver: Guessed archive format 'zip' from filename Elgato Video Capture-2.0.9.8722.zip
Unarchiver: Unarchived ~/Library/AutoPkg/Cache/com.github.ygini.pkg.ElgatoVideoCapture/downloads/Elgato Video Capture-2.0.9.8722.zip to ~/Library/AutoPkg/Cache/com.github.ygini.pkg.ElgatoVideoCapture/Elgato Video Capture
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.ygini.pkg.ElgatoVideoCapture/Elgato '
                         'Video Capture/Elgato Video Capture.app',
           'requirement': 'anchor apple generic and identifier '
                          '"com.elgato.VideoCapture" and (certificate '
                          'leaf[field.1.2.840.113635.100.6.1.9] /* exists */ '
                          'or certificate 1[field.1.2.840.113635.100.6.2.6] /* '
                          'exists */ and certificate '
                          'leaf[field.1.2.840.113635.100.6.1.13] /* exists */ '
                          'and certificate leaf[subject.OU] = Y93VXCB8Q5)'}}
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.ygini.pkg.ElgatoVideoCapture/Elgato Video Capture/Elgato Video Capture.app: valid on disk
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.ygini.pkg.ElgatoVideoCapture/Elgato Video Capture/Elgato Video Capture.app: satisfies its Designated Requirement
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.ygini.pkg.ElgatoVideoCapture/Elgato Video Capture/Elgato Video Capture.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Versioner
{'Input': {'input_plist_path': '~/Library/AutoPkg/Cache/com.github.ygini.pkg.ElgatoVideoCapture/Elgato '
                               'Video Capture/Elgato Video '
                               'Capture.app/Contents/Info.plist',
           'plist_version_key': 'CFBundleShortVersionString'}}
Versioner: No value supplied for skip_single_root_dir, setting default value of: False
Versioner: Found version 2.0.9 (8722) in file ~/Library/AutoPkg/Cache/com.github.ygini.pkg.ElgatoVideoCapture/Elgato Video Capture/Elgato Video Capture.app/Contents/Info.plist
{'Output': {'version': '2.0.9 (8722)'}}
AppPkgCreator
{'Input': {'app_path': '~/Library/AutoPkg/Cache/com.github.ygini.pkg.ElgatoVideoCapture/Elgato '
                       'Video Capture/Elgato Video Capture.app',
           'version': '2.0.9 (8722)'}}
AppPkgCreator: BundleID: com.elgato.VideoCapture
AppPkgCreator: Copied ~/Library/AutoPkg/Cache/com.github.ygini.pkg.ElgatoVideoCapture/Elgato Video Capture/Elgato Video Capture.app to ~/Library/AutoPkg/Cache/com.github.ygini.pkg.ElgatoVideoCapture/payload/Applications/Elgato Video Capture.app
AppPkgCreator: Connecting
AppPkgCreator: Sending packaging request
AppPkgCreator: Disconnecting
AppPkgCreator: Failed to close socket: [Errno 9] Bad file descriptor
Invalid package name
Failed.
Receipt written to ~/Library/AutoPkg/Cache/com.github.ygini.pkg.ElgatoVideoCapture/receipts/Elgato Video Capture.pkg-receipt-20241228-075749.plist
Processing Elgato Video Capture.munki.recipe...
WARNING: Elgato Video Capture.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
{'Input': {'re_pattern': 'href="(https://edge\\.elgato\\.com/video-capture/macos/[\\d\\.]+/Video_Capture_(?P<version>[\\d\\.]+)\\.zip)"',
           'request_headers': {'User-Agent': 'Mozilla/5.0 (Macintosh; Intel '
                                             'Mac OS X 10_15_7) '
                                             'AppleWebKit/537.36 (KHTML, like '
                                             'Gecko) Chrome/131.0.0.0 '
                                             'Safari/537.36'},
           'result_output_var_name': 'url',
           'url': 'https://help.elgato.com/hc/en-us/articles/360028243991-Elgato-Video-Capture-Software-Release-Notes'}}
URLTextSearcher: Found matching text (version): 2.0.9.8722
URLTextSearcher: Found matching text (url): https://edge.elgato.com/video-capture/macos/2.0.9/Video_Capture_2.0.9.8722.zip
{'Output': {'url': 'https://edge.elgato.com/video-capture/macos/2.0.9/Video_Capture_2.0.9.8722.zip',
            'version': '2.0.9.8722'}}
URLDownloader
{'Input': {'filename': 'Elgato Video Capture-2.0.9.8722.zip',
           'request_headers': {'User-Agent': 'Mozilla/5.0 (Macintosh; Intel '
                                             'Mac OS X 10_15_7) '
                                             'AppleWebKit/537.36 (KHTML, like '
                                             'Gecko) Chrome/131.0.0.0 '
                                             'Safari/537.36'},
           'url': 'https://edge.elgato.com/video-capture/macos/2.0.9/Video_Capture_2.0.9.8722.zip'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Mon, 21 Oct 2024 15:50:12 GMT
URLDownloader: Storing new ETag header: "a2c54aebbc3b7822b7f303da76dc6d3a"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.ygini.munki.ElgatoVideoCapture/downloads/Elgato Video Capture-2.0.9.8722.zip
{'Output': {'download_changed': True,
            'etag': '"a2c54aebbc3b7822b7f303da76dc6d3a"',
            'last_modified': 'Mon, 21 Oct 2024 15:50:12 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.ygini.munki.ElgatoVideoCapture/downloads/Elgato '
                        'Video Capture-2.0.9.8722.zip',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.ygini.munki.ElgatoVideoCapture/downloads/Elgato '
                                                                        'Video '
                                                                        'Capture-2.0.9.8722.zip'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Unarchiver
{'Input': {'archive_path': '~/Library/AutoPkg/Cache/com.github.ygini.munki.ElgatoVideoCapture/downloads/Elgato '
                           'Video Capture-2.0.9.8722.zip',
           'destination_path': '~/Library/AutoPkg/Cache/com.github.ygini.munki.ElgatoVideoCapture/Elgato '
                               'Video Capture',
           'purge_destination': True}}
Unarchiver: No value supplied for USE_PYTHON_NATIVE_EXTRACTOR, setting default value of: False
Unarchiver: Guessed archive format 'zip' from filename Elgato Video Capture-2.0.9.8722.zip
Unarchiver: Unarchived ~/Library/AutoPkg/Cache/com.github.ygini.munki.ElgatoVideoCapture/downloads/Elgato Video Capture-2.0.9.8722.zip to ~/Library/AutoPkg/Cache/com.github.ygini.munki.ElgatoVideoCapture/Elgato Video Capture
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.ygini.munki.ElgatoVideoCapture/Elgato '
                         'Video Capture/Elgato Video Capture.app',
           'requirement': 'anchor apple generic and identifier '
                          '"com.elgato.VideoCapture" and (certificate '
                          'leaf[field.1.2.840.113635.100.6.1.9] /* exists */ '
                          'or certificate 1[field.1.2.840.113635.100.6.2.6] /* '
                          'exists */ and certificate '
                          'leaf[field.1.2.840.113635.100.6.1.13] /* exists */ '
                          'and certificate leaf[subject.OU] = Y93VXCB8Q5)'}}
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.ygini.munki.ElgatoVideoCapture/Elgato Video Capture/Elgato Video Capture.app: valid on disk
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.ygini.munki.ElgatoVideoCapture/Elgato Video Capture/Elgato Video Capture.app: satisfies its Designated Requirement
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.ygini.munki.ElgatoVideoCapture/Elgato Video Capture/Elgato Video Capture.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Versioner
{'Input': {'input_plist_path': '~/Library/AutoPkg/Cache/com.github.ygini.munki.ElgatoVideoCapture/Elgato '
                               'Video Capture/Elgato Video '
                               'Capture.app/Contents/Info.plist',
           'plist_version_key': 'CFBundleShortVersionString'}}
Versioner: No value supplied for skip_single_root_dir, setting default value of: False
Versioner: Found version 2.0.9 (8722) in file ~/Library/AutoPkg/Cache/com.github.ygini.munki.ElgatoVideoCapture/Elgato Video Capture/Elgato Video Capture.app/Contents/Info.plist
{'Output': {'version': '2.0.9 (8722)'}}
DmgCreator
{'Input': {'dmg_path': '~/Library/AutoPkg/Cache/com.github.ygini.munki.ElgatoVideoCapture/Elgato '
                       'Video Capture.dmg',
           'dmg_root': '~/Library/AutoPkg/Cache/com.github.ygini.munki.ElgatoVideoCapture/Elgato '
                       'Video Capture'}}
DmgCreator: Created dmg from ~/Library/AutoPkg/Cache/com.github.ygini.munki.ElgatoVideoCapture/Elgato Video Capture at ~/Library/AutoPkg/Cache/com.github.ygini.munki.ElgatoVideoCapture/Elgato Video Capture.dmg
{'Output': {}}
MunkiImporter
{'Input': {'MUNKI_REPO': '/Users/Shared/munki_repo',
           'pkg_path': '~/Library/AutoPkg/Cache/com.github.ygini.munki.ElgatoVideoCapture/Elgato '
                       'Video Capture.dmg',
           'pkginfo': {'catalogs': ['testing'],
                       'description': ' ',
                       'developer': 'Elgato Systems GmbH',
                       'display_name': 'Elgato Video Capture',
                       'name': 'Elgato Video Capture',
                       'unattended_install': True},
           'repo_subdirectory': 'apps/Elgato Video Capture'}}
MunkiImporter: No value supplied for MUNKI_REPO_PLUGIN, setting default value of: FileRepo
MunkiImporter: No value supplied for MUNKILIB_DIR, setting default value of: /usr/local/munki
MunkiImporter: No value supplied for force_munki_repo_lib, setting default value of: False
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/Shared/munki_repo
MunkiImporter: Copied pkginfo to: /Users/Shared/munki_repo/pkgsinfo/apps/Elgato Video Capture/Elgato Video Capture-2.0.9 (8722).plist
MunkiImporter:            pkg to: /Users/Shared/munki_repo/pkgs/apps/Elgato Video Capture/Elgato Video Capture-2.0.9 (8722).dmg
{'Output': {'munki_importer_summary_result': {'data': {'catalogs': 'testing',
                                                       'icon_repo_path': '',
                                                       'name': 'Elgato Video '
                                                               'Capture',
                                                       'pkg_repo_path': 'apps/Elgato '
                                                                        'Video '
                                                                        'Capture/Elgato '
                                                                        'Video '
                                                                        'Capture-2.0.9 '
                                                                        '(8722).dmg',
                                                       'pkginfo_path': 'apps/Elgato '
                                                                       'Video '
                                                                       'Capture/Elgato '
                                                                       'Video '
                                                                       'Capture-2.0.9 '
                                                                       '(8722).plist',
                                                       'version': '2.0.9 '
                                                                  '(8722)'},
                                              'report_fields': ['name',
                                                                'version',
                                                                'catalogs',
                                                                'pkginfo_path',
                                                                'pkg_repo_path',
                                                                'icon_repo_path'],
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'imported into '
                                                              'Munki:'},
            'munki_info': {'_metadata': {'created_by': 'testuser',
                                         'creation_date': datetime.datetime(2024, 12, 28, 15, 58, 6),
                                         'munki_version': '6.6.3.4704',
                                         'os_version': '15.2'},
                           'autoremove': False,
                           'catalogs': ['testing'],
                           'description': ' ',
                           'developer': 'Elgato Systems GmbH',
                           'display_name': 'Elgato Video Capture',
                           'installer_item_hash': 'ec1237d65a9f61a6f4b04891e4b0cadc6bcd6e8fa9f1913457680c7bd3b7daf4',
                           'installer_item_location': 'apps/Elgato Video '
                                                      'Capture/Elgato Video '
                                                      'Capture-2.0.9 '
                                                      '(8722).dmg',
                           'installer_item_size': 44053,
                           'installer_type': 'copy_from_dmg',
                           'installs': [{'CFBundleIdentifier': 'com.elgato.VideoCapture',
                                         'CFBundleName': 'Elgato Video Capture',
                                         'CFBundleShortVersionString': '2.0.9 '
                                                                       '(8722)',
                                         'CFBundleVersion': '2.0.9 (8722)',
                                         'minosversion': '10.11',
                                         'path': '/Applications/Elgato Video '
                                                 'Capture.app',
                                         'type': 'application',
                                         'version_comparison_key': 'CFBundleShortVersionString'}],
                           'items_to_copy': [{'destination_path': '/Applications',
                                              'source_item': 'Elgato Video '
                                                             'Capture.app'}],
                           'minimum_os_version': '10.11',
                           'name': 'Elgato Video Capture',
                           'unattended_install': True,
                           'uninstall_method': 'remove_copied_items',
                           'uninstallable': True,
                           'version': '2.0.9 (8722)'},
            'munki_repo_changed': True,
            'pkg_repo_path': '/Users/Shared/munki_repo/pkgs/apps/Elgato Video '
                             'Capture/Elgato Video Capture-2.0.9 (8722).dmg',
            'pkginfo_repo_path': '/Users/Shared/munki_repo/pkgsinfo/apps/Elgato '
                                 'Video Capture/Elgato Video Capture-2.0.9 '
                                 '(8722).plist'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.ygini.munki.ElgatoVideoCapture/receipts/Elgato Video Capture.munki-receipt-20241228-075806.plist

The following recipes failed:
    Elgato Video Capture.pkg.recipe
        Error in com.github.ygini.pkg.ElgatoVideoCapture: Processor: AppPkgCreator: Error: Invalid package name

The following new items were downloaded:
    Download Path
    -------------
    ~/Library/AutoPkg/Cache/com.github.ygini.download.ElgatoVideoCapture/downloads/Elgato Video Capture-2.0.9.8722.zip
    ~/Library/AutoPkg/Cache/com.github.ygini.pkg.ElgatoVideoCapture/downloads/Elgato Video Capture-2.0.9.8722.zip
    ~/Library/AutoPkg/Cache/com.github.ygini.munki.ElgatoVideoCapture/downloads/Elgato Video Capture-2.0.9.8722.zip

The following new items were imported into Munki:
    Name                  Version       Catalogs  Pkginfo Path                                                       Pkg Repo Path                                                    Icon Repo Path
    ----                  -------       --------  ------------                                                       -------------                                                    --------------
    Elgato Video Capture  2.0.9 (8722)  testing   apps/Elgato Video Capture/Elgato Video Capture-2.0.9 (8722).plist  apps/Elgato Video Capture/Elgato Video Capture-2.0.9 (8722).dmg
```
