### PR TITLE
Fix Elasticsearch download recipe and add ARCH input variable

### DIFF
--- a/Elasticsearch/Elasticsearch.download.recipe
+++ b/Elasticsearch/Elasticsearch.download.recipe
@@ -2,27 +2,29 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>Description</key>
-	<string>Downloads the latest version of Elasticsearch.</string>
-	<key>Identifier</key>
-	<string>com.github.ygini.download.Elasticsearch</string>
-	<key>Input</key>
-	<dict>
-		<key>SOURCE_URL</key>
-		<string>https://www.elastic.co/downloads/elasticsearch</string>
+    <key>Description</key>
+    <string>Downloads the latest version of Elasticsearch.</string>
+    <key>Identifier</key>
+    <string>com.github.ygini.download.Elasticsearch</string>
+    <key>Input</key>
+    <dict>
+        <key>SOURCE_URL</key>
+        <string>https://www.elastic.co/guide/en/elasticsearch/reference/current/es-release-notes.html</string>
         <key>SEARCH_PATTERN</key>
-        <string>https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-(?P&lt;version&gt;.*?).tar.gz</string>
+        <string>Elasticsearch version ([\d\.]+)</string>
         <key>DOWNLOAD_BASE_URL</key>
         <string>https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-</string>
         <key>DOWNLOAD_SUFFIX</key>
         <string>.tar.gz</string>
-		<key>NAME</key>
-		<string>Elasticsearch</string>
-	</dict>
-	<key>MinimumVersion</key>
-	<string>0.5.0</string>
-	<key>Process</key>
-	<array>
+        <key>NAME</key>
+        <string>Elasticsearch</string>
+        <key>ARCH</key>
+        <string>x86_64</string>
+    </dict>
+    <key>MinimumVersion</key>
+    <string>0.5.0</string>
+    <key>Process</key>
+    <array>
         <dict>
             <key>Processor</key>
             <string>URLTextSearcher</string>
@@ -32,6 +34,8 @@
                 <string>%SOURCE_URL%</string>
                 <key>re_pattern</key>
                 <string>%SEARCH_PATTERN%</string>
+                <key>result_output_var_name</key>
+                <string>version</string>
             </dict>
         </dict>
         <dict>
@@ -40,15 +44,15 @@
             <key>Arguments</key>
             <dict>
                 <key>filename</key>
-                <string>%NAME%.tar.gz</string>
+                <string>%NAME%-%version%.tar.gz</string>
                 <key>url</key>
-                <string>%DOWNLOAD_BASE_URL%%version%%DOWNLOAD_SUFFIX%</string>
+                <string>%DOWNLOAD_BASE_URL%%version%-darwin-%ARCH%%DOWNLOAD_SUFFIX%</string>
             </dict>
         </dict>
         <dict>
             <key>Processor</key>
             <string>EndOfCheckPhase</string>
         </dict>
-	</array>
+    </array>
 </dict>
 </plist>

--- a/Elasticsearch/Elasticsearch.download.recipe
+++ b/Elasticsearch/Elasticsearch.download.recipe
@@ -3,7 +3,12 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>Downloads the latest version of Elasticsearch.</string>
+    <string>Downloads the latest version of Elasticsearch.
+    
+Valid values for ARCH include:
+- "x86_64" (default, Intel)
+- "aarch64" (Apple Silicon)
+</string>
     <key>Identifier</key>
     <string>com.github.ygini.download.Elasticsearch</string>
     <key>Input</key>


### PR DESCRIPTION
This PR fixes the ElasticSearch download recipe with hopefully more robust pattern matching based on the release notes. It also adds an ARCH input variable that can be used to specify whether to download Intel or Apple Silicon versions.

Verbose recipe run output with default (Intel) architecture:

```
% autopkg run -vvq 'Elasticsearch/Elasticsearch.download.recipe'
Processing Elasticsearch/Elasticsearch.download.recipe...
WARNING: Elasticsearch/Elasticsearch.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
{'Input': {'re_pattern': 'Elasticsearch version ([\\d\\.]+)',
           'result_output_var_name': 'version',
           'url': 'https://www.elastic.co/guide/en/elasticsearch/reference/current/es-release-notes.html'}}
URLTextSearcher: Found matching text (version): 8.17.0
{'Output': {'version': '8.17.0'}}
URLDownloader
{'Input': {'filename': 'Elasticsearch-8.17.0.tar.gz',
           'url': 'https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-8.17.0-darwin-x86_64.tar.gz'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Thu, 12 Dec 2024 14:40:17 GMT
URLDownloader: Storing new ETag header: "e7f3299f1e3bb52e37d993219dde860c-60"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.ygini.download.Elasticsearch/downloads/Elasticsearch-8.17.0.tar.gz
{'Output': {'download_changed': True,
            'etag': '"e7f3299f1e3bb52e37d993219dde860c-60"',
            'last_modified': 'Thu, 12 Dec 2024 14:40:17 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.ygini.download.Elasticsearch/downloads/Elasticsearch-8.17.0.tar.gz',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.ygini.download.Elasticsearch/downloads/Elasticsearch-8.17.0.tar.gz'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.ygini.download.Elasticsearch/receipts/Elasticsearch.download-receipt-20241228-073925.plist

The following new items were downloaded:
    Download Path
    -------------
    ~/Library/AutoPkg/Cache/com.github.ygini.download.Elasticsearch/downloads/Elasticsearch-8.17.0.tar.gz
```

Verbose recipe run output with Apple Silicon architecture:

```
% autopkg run -vvq 'Elasticsearch/Elasticsearch.download.recipe' -k ARCH=aarch64
Processing Elasticsearch/Elasticsearch.download.recipe...
WARNING: Elasticsearch/Elasticsearch.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
{'Input': {'re_pattern': 'Elasticsearch version ([\\d\\.]+)',
           'result_output_var_name': 'version',
           'url': 'https://www.elastic.co/guide/en/elasticsearch/reference/current/es-release-notes.html'}}
URLTextSearcher: Found matching text (version): 8.17.0
{'Output': {'version': '8.17.0'}}
URLDownloader
{'Input': {'filename': 'Elasticsearch-8.17.0.tar.gz',
           'url': 'https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-8.17.0-darwin-aarch64.tar.gz'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Thu, 12 Dec 2024 14:40:16 GMT
URLDownloader: Storing new ETag header: "e9b3fcb8a379501b296a96065ac88f7b-57"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.ygini.download.Elasticsearch/downloads/Elasticsearch-8.17.0.tar.gz
{'Output': {'download_changed': True,
            'etag': '"e9b3fcb8a379501b296a96065ac88f7b-57"',
            'last_modified': 'Thu, 12 Dec 2024 14:40:16 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.ygini.download.Elasticsearch/downloads/Elasticsearch-8.17.0.tar.gz',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.ygini.download.Elasticsearch/downloads/Elasticsearch-8.17.0.tar.gz'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.ygini.download.Elasticsearch/receipts/Elasticsearch.download-receipt-20241228-074428.plist

The following new items were downloaded:
    Download Path
    -------------
    ~/Library/AutoPkg/Cache/com.github.ygini.download.Elasticsearch/downloads/Elasticsearch-8.17.0.tar.gz
```

