### PR TITLE
Deprecate WorkSpace ONE UEM Agent recipes

### DIFF
--- a/WS1UEMAgent/WS1UEMAgent.download.recipe
+++ b/WS1UEMAgent/WS1UEMAgent.download.recipe
@@ -12,9 +12,18 @@
         <string>WS1UEMAgent</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.3.1</string>
+    <string>1.1</string>
     <key>Process</key>
     <array>
+        <dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>Consider switching to the WorkspaceONEIntelligentHub recipes in the hjuutilainen-recipes repo. This recipe is deprecated and will be removed in the future.</string>
+            </dict>
+        </dict>
         <dict>
             <key>Arguments</key>
             <dict>


### PR DESCRIPTION
This PR deprecates the non-functional WorkSpace ONE UEM Agent recipes and points users to an alternative in the hjuutilainen-recipes repo.