### PR TITLE
Fix SmartGit recipes and add ARCH input variable

### DIFF
--- a/SmartGit/SmartGit.download.recipe
+++ b/SmartGit/SmartGit.download.recipe
@@ -3,13 +3,20 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>Download recipe for SmartGit.</string>
+    <string>Download recipe for SmartGit.
+    
+Valid values for ARCH include:
+- "x86_64" (default, Intel)
+- "aarch64" (Apple Silicon)
+</string>
     <key>Identifier</key>
     <string>com.github.ygini.download.SmartGit</string>
     <key>Input</key>
     <dict>
         <key>NAME</key>
         <string>SmartGit</string>
+        <key>ARCH</key>
+        <string>x86_64</string>
     </dict>
     <key>MinimumVersion</key>
     <string>0.3.1</string>
@@ -23,14 +30,14 @@
                 <key>url</key>
                 <string>https://www.syntevo.com/smartgit/download/</string>
                 <key>re_pattern</key>      
-                <string>/downloads/smartgit/smartgit-macosx-(?P&lt;url_version_number&gt;.*?)\.dmg</string>
+                <string>/downloads/smartgit/smartgit-%ARCH%-(?P&lt;url_version_number&gt;.*?)\.dmg</string>
             </dict>
         </dict>
         <dict>
             <key>Arguments</key>
             <dict>
                 <key>url</key>
-                <string>https://www.syntevo.com/downloads/smartgit/smartgit-macosx-%url_version_number%.dmg</string>
+                <string>https://downloads.syntevo.com/downloads/smartgit/smartgit-%ARCH%-%url_version_number%.dmg</string>
             </dict>
             <key>Processor</key>
             <string>URLDownloader</string>


### PR DESCRIPTION
This PR updates the download pattern and page used to obtain SmartGit, and adds an ARCH input variable that can be used to specify whether to download Intel or Apple Silicon versions.

Verbose recipe run output with default (Intel) architecture:

```
% autopkg run -vvq 'SmartGit/SmartGit.download.recipe'
Processing SmartGit/SmartGit.download.recipe...
WARNING: SmartGit/SmartGit.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
{'Input': {'re_pattern': '/downloads/smartgit/smartgit-x86_64-(?P<url_version_number>.*?)\\.dmg',
           'url': 'https://www.syntevo.com/smartgit/download/'}}
URLTextSearcher: No value supplied for result_output_var_name, setting default value of: match
URLTextSearcher: Found matching text (url_version_number): 24_1_1
URLTextSearcher: Found matching text (match): 24_1_1
{'Output': {'match': '24_1_1', 'url_version_number': '24_1_1'}}
URLDownloader
{'Input': {'url': 'https://downloads.syntevo.com/downloads/smartgit/smartgit-x86_64-24_1_1.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Wed, 11 Dec 2024 15:30:33 GMT
URLDownloader: Storing new ETag header: "541fe54-6290047497840"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.ygini.download.SmartGit/downloads/smartgit-x86_64-24_1_1.dmg
{'Output': {'download_changed': True,
            'etag': '"541fe54-6290047497840"',
            'last_modified': 'Wed, 11 Dec 2024 15:30:33 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.ygini.download.SmartGit/downloads/smartgit-x86_64-24_1_1.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.ygini.download.SmartGit/downloads/smartgit-x86_64-24_1_1.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.ygini.download.SmartGit/receipts/SmartGit.download-receipt-20241228-192902.plist

The following new items were downloaded:
    Download Path
    -------------
    ~/Library/AutoPkg/Cache/com.github.ygini.download.SmartGit/downloads/smartgit-x86_64-24_1_1.dmg
```

Verbose recipe run output with Apple Silicon architecture:

```
% autopkg run -vvq 'SmartGit/SmartGit.download.recipe' -k ARCH=aarch64
Processing SmartGit/SmartGit.download.recipe...
WARNING: SmartGit/SmartGit.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
{'Input': {'re_pattern': '/downloads/smartgit/smartgit-aarch64-(?P<url_version_number>.*?)\\.dmg',
           'url': 'https://www.syntevo.com/smartgit/download/'}}
URLTextSearcher: No value supplied for result_output_var_name, setting default value of: match
URLTextSearcher: Found matching text (url_version_number): 24_1_1
URLTextSearcher: Found matching text (match): 24_1_1
{'Output': {'match': '24_1_1', 'url_version_number': '24_1_1'}}
URLDownloader
{'Input': {'url': 'https://downloads.syntevo.com/downloads/smartgit/smartgit-aarch64-24_1_1.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Wed, 11 Dec 2024 15:30:33 GMT
URLDownloader: Storing new ETag header: "534ee8c-6290047497840"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.ygini.download.SmartGit/downloads/smartgit-aarch64-24_1_1.dmg
{'Output': {'download_changed': True,
            'etag': '"534ee8c-6290047497840"',
            'last_modified': 'Wed, 11 Dec 2024 15:30:33 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.ygini.download.SmartGit/downloads/smartgit-aarch64-24_1_1.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.ygini.download.SmartGit/downloads/smartgit-aarch64-24_1_1.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.ygini.download.SmartGit/receipts/SmartGit.download-receipt-20241228-192919.plist

The following new items were downloaded:
    Download Path
    -------------
    ~/Library/AutoPkg/Cache/com.github.ygini.download.SmartGit/downloads/smartgit-aarch64-24_1_1.dmg
```
