### PR TITLE
Deprecate SketchUp Make recipes

### DIFF
--- a/SketchupMake/SketchUpMake.download.recipe
+++ b/SketchupMake/SketchUpMake.download.recipe
@@ -14,9 +14,18 @@
         <string>fr</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.2.0</string>
+    <string>1.1</string>
     <key>Process</key>
     <array>
+		<dict>
+			<key>Processor</key>
+			<string>DeprecationWarning</string>
+			<key>Arguments</key>
+		<dict>
+				<key>warning_message</key>
+				<string>SketchUp Make is no longer available for download (details: https://help.sketchup.com/en/make-access). This recipe is deprecated and will be removed in the future.</string>
+			</dict>
+		</dict>
     	<dict>
 			<key>Processor</key>
 			<string>URLTextSearcher</string>


### PR DESCRIPTION
This PR deprecates the SketchUp Make recipes, since that software is no longer available to download ([details](https://help.sketchup.com/en/make-access)).