### PR TITLE
Deprecate MestReNova recipes

### DIFF
--- a/MestReNova/MestReNova.download.recipe
+++ b/MestReNova/MestReNova.download.recipe
@@ -12,9 +12,18 @@
         <string>MestReNova</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.3.1</string>
+    <string>1.1</string>
     <key>Process</key>
     <array>
+        <dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>Consider switching to the MestReNova recipes in the andrewvalentine-recipes repo. This recipe is deprecated and will be removed in the future.</string>
+            </dict>
+        </dict>
         <dict>
             <key>Processor</key>
             <string>URLTextSearcher</string>


### PR DESCRIPTION
This PR deprecates the MestReNova recipes and points users to equivalents in the andrewvalentine-recipes repo, which include code signature verification.