### PR TITLE
Update PHPComposer.pkg.recipe

### DIFF
--- a/Composer/PHPComposer.pkg.recipe
+++ b/Composer/PHPComposer.pkg.recipe
@@ -43,7 +43,7 @@
                 <key>source_path</key>
                 <string>%pathname%</string>
                 <key>destination_path</key>
-                <string>%pkgroot%/usr/local/bin/</string>
+                <string>%pkgroot%/usr/local/bin/composer</string>
             </dict>
         </dict>
         <dict>
@@ -75,7 +75,7 @@
     					</dict>
     					<dict>
     						<key>path</key>
-                    		<string>/usr/local/bin/%NAME%.phar</string>
+                    		<string>/usr/local/bin/composer</string>
     						<key>user</key>
                     		<string>root</string>
     						<key>group</key>


### PR DESCRIPTION
Hi, @ygini 

The PHPComposer pkg recipe is currently failing, this is due the version number being in the file name.
```
Copier
{'Input': {'destination_path': '/Users/sadmin/Library/AutoPkg/Cache/local.munki.PHPComposer/composer/usr/local/bin/',
           'source_path': '/Users/sadmin/Library/AutoPkg/Cache/local.munki.PHPComposer/downloads/composer-2.8.6.phar'}}
Copier: Parsed dmg results: dmg_path: /Users/sadmin/Library/AutoPkg/Cache/local.munki.PHPComposer/downloads/composer-2.8.6.phar, dmg: , dmg_source_path: 
Copier: Copied /Users/sadmin/Library/AutoPkg/Cache/local.munki.PHPComposer/downloads/composer-2.8.6.phar to /Users/sadmin/Library/AutoPkg/Cache/local.munki.PHPComposer/composer/usr/local/bin/
{'Output': {}}
PkgCreator
{'Input': {'pkg_request': {'chown': [{'group': 'wheel',
                                      'path': '/usr',
                                      'user': 'root'},
                                     {'group': 'wheel',
                                      'mode': '0755',
                                      'path': '/usr/local/bin/composer.phar',
                                      'user': 'root'}],
                           'id': 'com.github.ygini.pkg.PHPComposer',
                           'options': 'purge_ds_store',
                           'pkgdir': '/Users/sadmin/Library/AutoPkg/Cache/local.munki.PHPComposer/composer',
                           'pkgname': 'composer-2.8.6',
                           'version': '2.8.6'}}}
PkgCreator: Connecting
PkgCreator: Sending packaging request
PkgCreator: Disconnecting
PkgCreator: Failed to close socket: [Errno 9] Bad file descriptor
chown path usr/local/bin/composer.phar does not exist
Failed.
Receipt written to /Users/sadmin/Library/AutoPkg/Cache/local.munki.PHPComposer/receipts/PHPComposer.munki-receipt-20250402-131228.plist

The following recipes failed:
    /Users/sadmin/Library/AutoPkg/RecipeOverrides/PHPComposer.munki.recipe
        Error in local.munki.PHPComposer: Processor: PkgCreator: Error: chown path usr/local/bin/composer.phar does not exist
```

This PR updates `Copier` and `PkgCreator` to remove the version and the file extension from the file name which is what is suggested in the vendors documentation: https://getcomposer.org/doc/00-intro.md#globally 

Output from a successful -v run 
```
autopkg run -v PHPComposer.munki.recipe
Looking for com.github.ygini.pkg.PHPComposer...
Did not find com.github.ygini.pkg.PHPComposer in recipe map
Rebuilding recipe map with current working directories...
Looking for com.github.ygini.pkg.PHPComposer...
Found com.github.ygini.pkg.PHPComposer in recipe map
Looking for com.github.ygini.download.PHPComposer...
Found com.github.ygini.download.PHPComposer in recipe map
**load_recipe time: 0.014847291997284628
Processing PHPComposer.munki.recipe...
WARNING: PHPComposer.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
URLTextSearcher: Found matching text (version): 2.8.6
URLDownloader
URLDownloader: Storing new Last-Modified header: Tue, 25 Feb 2025 12:03:50 GMT
URLDownloader: Downloaded /Users/paul.cossey/Library/AutoPkg/Cache/com.github.ygini.munki.PHPComposer/downloads/composer-2.8.6.phar
EndOfCheckPhase
PkgRootCreator
PkgRootCreator: Created /Users/paul.cossey/Library/AutoPkg/Cache/com.github.ygini.munki.PHPComposer/composer
PkgRootCreator: Created /Users/paul.cossey/Library/AutoPkg/Cache/com.github.ygini.munki.PHPComposer/composer/usr
PkgRootCreator: Created /Users/paul.cossey/Library/AutoPkg/Cache/com.github.ygini.munki.PHPComposer/composer/usr/local
PkgRootCreator: Created /Users/paul.cossey/Library/AutoPkg/Cache/com.github.ygini.munki.PHPComposer/composer/usr/local/bin
Copier
Copier: Copied /Users/paul.cossey/Library/AutoPkg/Cache/com.github.ygini.munki.PHPComposer/downloads/composer-2.8.6.phar to /Users/paul.cossey/Library/AutoPkg/Cache/com.github.ygini.munki.PHPComposer/composer/usr/local/bin/composer
PkgCreator
PkgCreator: Connecting
PkgCreator: Sending packaging request
PkgCreator: Disconnecting
MunkiImporter
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/Shared/munki_repo
MunkiImporter: Copied pkginfo to: /Users/Shared/munki_repo/pkgsinfo/dev/phpcomposer/composer-2.8.6.plist
MunkiImporter:            pkg to: /Users/Shared/munki_repo/pkgs/dev/phpcomposer/composer-2.8.6.pkg
Receipt written to /Users/paul.cossey/Library/AutoPkg/Cache/com.github.ygini.munki.PHPComposer/receipts/PHPComposer.munki-receipt-20250402-150413.plist

The following new items were downloaded:
    Download Path                                                                                              
    -------------                                                                                              
    /Users/paul.cossey/Library/AutoPkg/Cache/com.github.ygini.munki.PHPComposer/downloads/composer-2.8.6.phar  

The following packages were built:
    Identifier                        Version  Pkg Path                                                                                                 
    ----------                        -------  --------                                                                                                 
    com.github.ygini.pkg.PHPComposer  2.8.6    /Users/paul.cossey/Library/AutoPkg/Cache/com.github.ygini.munki.PHPComposer/composer/composer-2.8.6.pkg  

The following new items were imported into Munki:
    Name      Version  Catalogs  Pkginfo Path                          Pkg Repo Path                       Icon Repo Path  
    ----      -------  --------  ------------                          -------------                       --------------  
    composer  2.8.6    testing   dev/phpcomposer/composer-2.8.6.plist  dev/phpcomposer/composer-2.8.6.pkg
```