### PR TITLE
Updating Postico recipes to swap to DMG and use Changelog to identify latest

### DIFF
--- a/Postico/Postico.download.recipe
+++ b/Postico/Postico.download.recipe
@@ -12,23 +12,30 @@
         <string>Postico</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.3.1</string>
+    <string>2.3</string>
     <key>Process</key>
     <array>
         <dict>
             <key>Arguments</key>
             <dict>
                 <key>url</key>
-                <string>https://eggerapps.at/postico/download/</string>
+                <string>https://releases.eggerapps.at/postico2/changelog?update_channel=2</string>
+                <key>re_pattern</key>
+                <string>https://downloads\.eggerapps\.at/postico/postico-\d+\.dmg</string>
+            </dict>
+            <key>Processor</key>
+            <string>URLTextSearcher</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>url</key>
+                <string>%match%</string>
                 <key>filename</key>
-                <string>%NAME%.zip</string>
+                <string>%NAME%.dmg</string>
             </dict>
             <key>Processor</key>
             <string>URLDownloader</string>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>Unarchiver</string>
         </dict>
         <dict>
             <key>Processor</key>
@@ -36,7 +43,7 @@
             <key>Arguments</key>
             <dict>
                 <key>input_path</key>
-                <string>%RECIPE_CACHE_DIR%/Postico/Postico.app</string>
+                <string>%pathname%/Postico 2.app</string>
                 <key>requirement</key>
                   <string>anchor apple generic and identifier "at.eggerapps.Postico" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = ZF84SJ5A3G)</string>
             </dict>

--- a/Postico/Postico.munki.recipe
+++ b/Postico/Postico.munki.recipe
@@ -7,7 +7,7 @@
     <key>Identifier</key>
     <string>com.github.ygini.munki.Postico</string>
     <key>MinimumVersion</key>
-    <string>0.4.2</string>
+    <string>2.3</string>
     <key>Input</key>
     <dict>
         <key>NAME</key>
@@ -38,28 +38,17 @@
     <string>com.github.ygini.download.Postico</string>
     <key>Process</key>
     <array>
-        <dict>
-            <key>Arguments</key>
-            <dict>
-                <key>dmg_root</key>
-                <string>%RECIPE_CACHE_DIR%/%NAME%</string>
-                <key>dmg_path</key>
-                <string>%RECIPE_CACHE_DIR%/%NAME%.dmg</string>
-            </dict>
-            <key>Processor</key>
-            <string>DmgCreator</string>
-        </dict>
-        <dict>
-            <key>Arguments</key>
-            <dict>
-                <key>pkg_path</key>
-                <string>%RECIPE_CACHE_DIR%/%NAME%.dmg</string>
-                <key>repo_subdirectory</key>
-                <string>%MUNKI_REPO_SUBDIR%</string>
-            </dict>
-            <key>Processor</key>
-            <string>MunkiImporter</string>
-        </dict>
-    </array>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>pkg_path</key>
+				<string>%pathname%</string>
+				<key>repo_subdirectory</key>
+				<string>%MUNKI_REPO_SUBDIR%</string>
+			</dict>
+			<key>Processor</key>
+			<string>MunkiImporter</string>
+		</dict>
+	</array>
 </dict>
 </plist>

--- a/Postico/Postico.pkg.recipe
+++ b/Postico/Postico.pkg.recipe
@@ -14,19 +14,12 @@
 		<string>Postico</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>1.0.0</string>
+	<string>2.3</string>
 	<key>ParentRecipe</key>
 	<string>com.github.ygini.download.Postico</string>
 	<key>Process</key>
 	<array>
 		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>app_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/*.app</string>
-				<key>pkg_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%.dmg</string>
-			</dict>
 			<key>Processor</key>
 			<string>AppPkgCreator</string>
 		</dict>


### PR DESCRIPTION
There's no longer .zip files available on the download page and the appcast URL doesn't really seem to be valid. This change uses the changelog page to identify the latest version and get the DMG.