### PR TITLE
Removal of unused `options` from PkgCreator arguments

### DIFF
--- a/CNIL/PIA.pkg.recipe
+++ b/CNIL/PIA.pkg.recipe
@@ -62,8 +62,6 @@
 					</array>
 					<key>id</key>
 					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/Composer/PHPComposer.pkg.recipe
+++ b/Composer/PHPComposer.pkg.recipe
@@ -61,8 +61,6 @@
                     <string>%PKG_ID%</string>
                     <key>version</key>
                     <string>%version%</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>chown</key>
     				<array>
     					<dict>

--- a/Elasticsearch/Elasticsearch.pkg.recipe
+++ b/Elasticsearch/Elasticsearch.pkg.recipe
@@ -89,8 +89,6 @@
                     <string>%PKG_ID%</string>
                     <key>version</key>
                     <string>%version%</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>scripts</key>
                     <string>pkg-scripts</string>
                     <key>chown</key>

--- a/Krystof Vasa/Downie.pkg.recipe
+++ b/Krystof Vasa/Downie.pkg.recipe
@@ -39,8 +39,6 @@
 					</array>
 					<key>id</key>
 					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/SketchupMake/SketchUpMake.pkg.recipe
+++ b/SketchupMake/SketchUpMake.pkg.recipe
@@ -78,8 +78,6 @@
                     <string>%RECIPE_CACHE_DIR%</string>
                     <key>id</key>
                     <string>%PKG_ID%</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>chown</key>
                     <array>
                         <dict>

--- a/Techno-Grafik Christian Lackner eU/iTaskX3.pkg.recipe
+++ b/Techno-Grafik Christian Lackner eU/iTaskX3.pkg.recipe
@@ -39,8 +39,6 @@
 					</array>
 					<key>id</key>
 					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/Texpad/Texpad.pkg.recipe
+++ b/Texpad/Texpad.pkg.recipe
@@ -64,8 +64,6 @@
 					</array>
 					<key>id</key>
 					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/Texpad/TexpadBeta.pkg.recipe
+++ b/Texpad/TexpadBeta.pkg.recipe
@@ -64,8 +64,6 @@
 					</array>
 					<key>id</key>
 					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>


### PR DESCRIPTION
Hundreds of recipes dating from the very beginning of AutoPkg use the `options` key in the `pkg_request` argument of PkgCreator:

```xml
<key>options</key>
<string>purge_ds_store</string>
```

However, this key doesn't serve any purpose at all. The `options` key is ignored and not passed along to `pkgbuild`, regardless of its presence or contents. It appears that this has been the case since the very first public release of AutoPkg 0.1.0!

So this pull request (one of over 100) formally ends this practice and removes the unused and unneeded `options` key from all recipes in the AutoPkg org that use PkgCreator.

Thanks for considering!

_This PR was submitted using [Repo Lasso](https://github.com/homebysix/repo-lasso) v1.2.0._