### PR TITLE
Change Mattermost parent to peshay download

### DIFF
--- a/Mattermost/Mattermost.download.recipe
+++ b/Mattermost/Mattermost.download.recipe
@@ -28,6 +28,15 @@
 	<key>Process</key>
 	<array>
         <dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>Consider switching to the Mattermost recipes in the peshay-recipes repo. This recipe is deprecated and will be removed in the future.</string>
+            </dict>
+        </dict>
+        <dict>
                 <key>Arguments</key>
                 <dict>
                         <key>github_repo</key>

--- a/Mattermost/Mattermost.munki.recipe
+++ b/Mattermost/Mattermost.munki.recipe
@@ -35,7 +35,7 @@
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>
 	<key>ParentRecipe</key>
-	<string>com.github.ygini.download.Mattermost</string>
+	<string>com.github.peshay.download.Mattermost</string>
 	<key>Process</key>
 	<array>
         <dict>


### PR DESCRIPTION
The Mattermost.download recipe in this repo is similar in function the earlier-created ones in peshay-recipes. This PR adjusts your munki recipe to use peshay's download recipe as a parent.

This consolidation will help simplify search results and lower maintenance effort. Thank you!
