### PR TITLE
Add architecture support for AWS VPN

### DIFF
--- a/AWS VPN Client/AWS VPN Client.download.recipe
+++ b/AWS VPN Client/AWS VPN Client.download.recipe
@@ -3,18 +3,48 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>Downloads the latest version of AWS VPN Client.</string>
+    <string>Downloads the latest version of AWS VPN Client. Set ARCH to either arm64 or x86_64.</string>
     <key>Identifier</key>
     <string>com.github.ygini.download.AWSVPNClient</string>
     <key>Input</key>
     <dict>
         <key>NAME</key>
         <string>AWS VPN Client</string>
+        <key>ARCH</key>
+        <string>arm64</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>1.0.0</string>
+    <string>2.7.6</string>
     <key>Process</key>
     <array>
+        <dict>
+            <key>Processor</key>
+            <string>FindAndReplace</string>
+            <key>Arguments</key>
+            <dict>
+                <key>input_string</key>
+                <string>%ARCH%</string>
+                <key>find</key>
+                <string>arm64</string>
+                <key>replace</key>
+                <string>_ARM64</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>FindAndReplace</string>
+            <key>Arguments</key>
+            <dict>
+                <key>input_string</key>
+                <string>%output_string%</string>
+                <key>find</key>
+                <string>x86_64</string>
+                <key>replace</key>
+                <string></string>
+                <key>result_output_var_name</key>
+                <string>DOWNLOAD_ARCH</string>
+            </dict>
+        </dict>
         <dict>
             <key>Processor</key>
             <string>URLTextSearcher</string>
@@ -23,7 +53,9 @@
                 <key>url</key>
                 <string>https://docs.aws.amazon.com/vpn/latest/clientvpn-user/client-vpn-connect-macos-release-notes.html</string>
                 <key>re_pattern</key>
-                <string>https://.*?\.cloudfront\.net/OSX/.*?/AWS_VPN_Client\.pkg</string>
+                <string>https://.*?\.cloudfront\.net/OSX%DOWNLOAD_ARCH%/.*?/AWS_VPN_Client%DOWNLOAD_ARCH%\.pkg</string>
+                <key>result_output_var_name</key>
+                <string>url</string>
             </dict>
         </dict>
         <dict>
@@ -32,9 +64,9 @@
             <key>Arguments</key>
             <dict>
                 <key>filename</key>
-                <string>%NAME%.pkg</string>
+                <string>%NAME%-%ARCH%.pkg</string>
                 <key>url</key>
-                <string>%match%</string>
+                <string>%url%</string>
             </dict>
         </dict>
         <dict>

--- a/AWS VPN Client/AWS VPN Client.munki.recipe
+++ b/AWS VPN Client/AWS VPN Client.munki.recipe
@@ -7,15 +7,19 @@
     <key>Description</key>
     <string>Downloads the latest version of AWS VPN Client and imports it into Munki.
 
+Set ARCH to either arm64 or x86_64.
+
 Set the DERIVE_MIN_OS variable to a non-empty string to set the minimum_os_version via MunkiInstallsItemsCreator. This requires a minimum AutoPkg version of 2.7 please update if you're not already running it.</string>
     <key>Identifier</key>
     <string>com.github.ygini.munki.AWSVPNClient</string>
     <key>Input</key>
     <dict>
-    	<key>DERIVE_MIN_OS</key>
+        <key>ARCH</key>
+        <string>arm64</string>
+        <key>DERIVE_MIN_OS</key>
         <string>YES</string>
         <key>MUNKI_REPO_SUBDIR</key>
-        <string>apps/%NAME%</string>
+        <string>apps/%NAME%/%ARCH%</string>
         <key>NAME</key>
         <string>AWS VPN Client</string>
         <key>pkginfo</key>
@@ -39,12 +43,16 @@ Set the DERIVE_MIN_OS variable to a non-empty string to set the minimum_os_versi
             <string>Remote Access</string>
             <key>name</key>
             <string>%NAME%</string>
+            <key>supported_architectures</key>
+            <array>
+                <string>%ARCH%</string>
+            </array>
             <key>unattended_install</key>
             <true/>
         </dict>
     </dict>
     <key>MinimumVersion</key>
-    <string>2.7</string>
+    <string>2.7.6</string>
     <key>ParentRecipe</key>
     <string>com.github.ygini.download.AWSVPNClient</string>
     <key>Process</key>
@@ -55,7 +63,7 @@ Set the DERIVE_MIN_OS variable to a non-empty string to set the minimum_os_versi
             <key>destination_path</key>
             <string>%RECIPE_CACHE_DIR%/unpack</string>
             <key>flat_pkg_path</key>
-            <string>%RECIPE_CACHE_DIR%/downloads/%NAME%.pkg</string>
+            <string>%pathname%</string>
             <key>purge_destination</key>
             <true/>
         </dict>
@@ -115,6 +123,18 @@ Set the DERIVE_MIN_OS variable to a non-empty string to set the minimum_os_versi
             </dict>
             <key>Processor</key>
             <string>MunkiImporter</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>PathDeleter</string>
+            <key>Arguments</key>
+            <dict>
+                <key>path_list</key>
+                <array>
+                    <string>%RECIPE_CACHE_DIR%/Applications</string>
+                    <string>%RECIPE_CACHE_DIR%/unpack</string>
+                </array>
+            </dict>
         </dict>
     </array>
 </dict>


### PR DESCRIPTION
AWS VPN Client now provides Apple Silicon support via a separate package.

This PR adds dual architecture support via a single `ARCH` variable to cover both the download URL and Munki's array.

It also adds a little cleanup at the end.

-vv runs:
[munki-arm64.log](https://github.com/user-attachments/files/23658389/munki-arm64.log)
[munki-x86_64.log](https://github.com/user-attachments/files/23658390/munki-x86_64.log)
